### PR TITLE
Various fixes

### DIFF
--- a/src/examples/libswd_drv_openocd.c
+++ b/src/examples/libswd_drv_openocd.c
@@ -62,7 +62,7 @@ int libswd_drv_mosi_8(libswd_ctx_t *libswdctx, libswd_cmd_t *cmd, char *data, in
  static char misodata[8], mosidata[8];
 
  /* Split output data into char array. */
- for (i=0;i<8;i++) mosidata[(nLSBfirst==LIBSWD_DIR_LSBFIRST)?(i):(bits-1-i)]=((1<<i)&(*data))?1:0; 
+ for (i=0;i<8;i++) mosidata[(nLSBfirst==LIBSWD_DIR_LSBFIRST)?(i):(bits-1-i)]=((1<<i)&(*data))?1:0;
  /* Then send that array into interface hardware. */
  res=jtag_interface->transfer(NULL, bits, mosidata, misodata, 0);
  if (res<0) return LIBSWD_ERROR_DRIVER;
@@ -91,7 +91,7 @@ int libswd_drv_mosi_32(libswd_ctx_t *libswdctx, libswd_cmd_t *cmd, int *data, in
  static char misodata[32], mosidata[32];
 
  //UrJTAG drivers shift data LSB-First.
- for (i=0;i<32;i++) mosidata[(nLSBfirst==LIBSWD_DIR_LSBFIRST)?(i):(bits-1-i)]=((1<<i)&(*data))?1:0; 
+ for (i=0;i<32;i++) mosidata[(nLSBfirst==LIBSWD_DIR_LSBFIRST)?(i):(bits-1-i)]=((1<<i)&(*data))?1:0;
  res=jtag_interface->transfer(NULL, bits, mosidata, misodata, 0);
  if (res<0) return LIBSWD_ERROR_DRIVER;
  return i;
@@ -152,7 +152,7 @@ int libswd_drv_miso_32(libswd_ctx_t *libswdctx, libswd_cmd_t *cmd, int *data, in
  LOG_DEBUG("OpenOCD's libswd_drv_miso_32(libswdctx=@%p, cmd=@%p, data=@%p, bits=%d, nLSBfirst=0x%02X) reads: 0x%08X", (void*)libswdctx, (void*)cmd, (void*)data, bits, nLSBfirst, *data);
  LOG_DEBUG("OpenOCD's libswd_drv_miso_32() reads: 0x%08X\n", *data);
  return i;
-}       
+}
 
 /**
  * This function sets interface buffers to MOSI direction.
@@ -161,12 +161,12 @@ int libswd_drv_miso_32(libswd_ctx_t *libswdctx, libswd_cmd_t *cmd, int *data, in
  * OpenOCD driver must support "RnW" signal to drive output buffers for TRN.
  * \param *libswdctx is the swd context to work on.
  * \param bits specify how many clock cycles must be used for TRN.
- * \return number of bits transmitted or negative LIBSWD_ERROR code on failure. 
+ * \return number of bits transmitted or negative LIBSWD_ERROR code on failure.
  */
 int libswd_drv_mosi_trn(libswd_ctx_t *libswdctx, int bits){
  LOG_DEBUG("OpenOCD's libswd_drv_mosi_trn(libswdctx=@%p, bits=%d)\n", (void*)libswdctx, bits);
  if (bits<LIBSWD_TURNROUND_MIN_VAL && bits>LIBSWD_TURNROUND_MAX_VAL)
-  return LIBSWD_ERROR_TURNAROUND; 
+  return LIBSWD_ERROR_TURNAROUND;
 
  int res, val=0;
  static char buf[LIBSWD_TURNROUND_MAX_VAL];
@@ -175,7 +175,7 @@ int libswd_drv_mosi_trn(libswd_ctx_t *libswdctx, int bits){
  if (res<0) return LIBSWD_ERROR_DRIVER;
 
  /* Clock specified number of bits for proper TRN transaction. */
- res=jtag_interface->transfer(NULL, bits, buf, buf, 0); 
+ res=jtag_interface->transfer(NULL, bits, buf, buf, 0);
  if (res<0) return LIBSWD_ERROR_DRIVER;
 
  return bits;
@@ -188,12 +188,12 @@ int libswd_drv_mosi_trn(libswd_ctx_t *libswdctx, int bits){
  * OpenOCD driver must support "RnW" signal to drive output buffers for TRN.
  * \param *libswdctx is the swd context to work on.
  * \param bits specify how many clock cycles must be used for TRN.
- * \return number of bits transmitted or negative LIBSWD_ERROR code on failure. 
+ * \return number of bits transmitted or negative LIBSWD_ERROR code on failure.
  */
 int libswd_drv_miso_trn(libswd_ctx_t *libswdctx, int bits){
  LOG_DEBUG("OpenOCD's libswd_drv_miso_trn(libswdctx=@%p, bits=%d)\n", (void*)libswdctx, bits);
  if (bits<LIBSWD_TURNROUND_MIN_VAL && bits>LIBSWD_TURNROUND_MAX_VAL)
-  return LIBSWD_ERROR_TURNAROUND; 
+  return LIBSWD_ERROR_TURNAROUND;
 
  static int res, val=1;
  static char buf[LIBSWD_TURNROUND_MAX_VAL];
@@ -203,9 +203,9 @@ int libswd_drv_miso_trn(libswd_ctx_t *libswdctx, int bits){
  if (res<0) return LIBSWD_ERROR_DRIVER;
 
  /* Clock specified number of bits for proper TRN transaction. */
- res=jtag_interface->transfer(NULL, bits, buf, buf, 0); 
+ res=jtag_interface->transfer(NULL, bits, buf, buf, 0);
  if (res<0) return LIBSWD_ERROR_DRIVER;
- 
+
  return bits;
 }
 
@@ -215,7 +215,7 @@ int libswd_drv_miso_trn(libswd_ctx_t *libswdctx, int bits){
  * \param *libswdctx is the context to work on.
  * \param loglevel is the OpenOCD numerical value of actual loglevel to force
  *  on LibSWD, or -1 to inherit from actual global settings of OpenOCD.
- * \return LIBSWD_OK on success, negative LIBSWD_ERROR code on failure. 
+ * \return LIBSWD_OK on success, negative LIBSWD_ERROR code on failure.
  */
 int libswd_log_level_inherit(libswd_ctx_t *libswdctx, int loglevel){
  LOG_DEBUG("OpenOCD's libswd_log_level_inherit(libswdctx=@%p, loglevel=%d)\n", (void*)libswdctx, loglevel);
@@ -248,7 +248,7 @@ int libswd_log_level_inherit(libswd_ctx_t *libswdctx, int loglevel){
   default:
    new_swdlevel=LIBSWD_LOGLEVEL_NORMAL;
  }
-                                
+
  int res=libswd_log_level_set(libswdctx, new_swdlevel);
  if (res<0) {
   LOG_ERROR("libswd_log_level_set() failed (%s)\n", libswd_error_string(res));
@@ -263,7 +263,7 @@ int libswd_log_level_inherit(libswd_ctx_t *libswdctx, int loglevel){
   */
 int libswd_log(libswd_ctx_t *libswdctx, libswd_loglevel_t loglevel, char *msg, ...){
  if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
- if (loglevel > LIBSWD_LOGLEVEL_MAX) return LIBSWD_ERROR_PARAM; 
+ if (loglevel > LIBSWD_LOGLEVEL_MAX) return LIBSWD_ERROR_PARAM;
 
  if (loglevel > libswdctx->config.loglevel) return LIBSWD_OK;
  va_list ap;

--- a/src/examples/libswd_drv_urjtag.c
+++ b/src/examples/libswd_drv_urjtag.c
@@ -58,7 +58,7 @@ int libswd_drv_mosi_8(libswd_ctx_t *libswdctx, libswd_cmd_t *cmd, char *data, in
  static char misodata[8], mosidata[8];
 
  //UrJTAG drivers shift data LSB-First.
- for (i=0;i<8;i++) mosidata[(nLSBfirst==LIBSWD_DIR_LSBFIRST)?(i):(7-i)]=((1<<i)&(*data))?1:0; 
+ for (i=0;i<8;i++) mosidata[(nLSBfirst==LIBSWD_DIR_LSBFIRST)?(i):(7-i)]=((1<<i)&(*data))?1:0;
  res=urj_tap_cable_transfer((urj_cable_t *)libswdctx->driver->device, bits, mosidata, misodata);
  if (res<0) return LIBSWD_ERROR_DRIVER;
  urj_tap_cable_flush((urj_cable_t *)libswdctx->driver->device, URJ_TAP_CABLE_COMPLETELY);
@@ -85,7 +85,7 @@ int libswd_drv_mosi_32(libswd_ctx_t *libswdctx, libswd_cmd_t *cmd, int *data, in
  static char misodata[32], mosidata[32];
 
  //UrJTAG drivers shift data LSB-First.
- for (i=0;i<32;i++) mosidata[(nLSBfirst==LIBSWD_DIR_LSBFIRST)?(i):(31-i)]=((1<<i)&(*data))?1:0; 
+ for (i=0;i<32;i++) mosidata[(nLSBfirst==LIBSWD_DIR_LSBFIRST)?(i):(31-i)]=((1<<i)&(*data))?1:0;
  res=urj_tap_cable_transfer((urj_cable_t *)libswdctx->driver->device, bits, mosidata, misodata);
  if (res<0) return LIBSWD_ERROR_DRIVER;
  urj_tap_cable_flush((urj_cable_t *)libswdctx->driver->device, URJ_TAP_CABLE_COMPLETELY);
@@ -146,24 +146,24 @@ int libswd_drv_miso_32(libswd_ctx_t *libswdctx, libswd_cmd_t *cmd, int *data, in
  *data=0;
  for (i=0;i<bits;i++) *data|=(misodata[(nLSBfirst==LIBSWD_DIR_LSBFIRST)?(bits-1-i):(i)]?(1<<i):0);
  return i;
-}       
+}
 
 /**
  * This function sets interface buffers to MOSI direction.
  * MOSI (Master Output Slave Input) is a SWD Write operation.
  * \param *libswdctx is the swd context to work on.
  * \param bits specify how many clock cycles must be used for TRN.
- * \return number of bits transmitted or negative LIBSWD_ERROR code on failure. 
+ * \return number of bits transmitted or negative LIBSWD_ERROR code on failure.
  */
 int libswd_drv_mosi_trn(libswd_ctx_t *libswdctx, int bits){
  if (bits<LIBSWD_TURNROUND_MIN_VAL && bits>LIBSWD_TURNROUND_MAX_VAL)
-  return LIBSWD_ERROR_TURNAROUND; 
+  return LIBSWD_ERROR_TURNAROUND;
 
  int res;
- res=urj_tap_cable_set_signal((urj_cable_t *)libswdctx->driver->device, URJ_POD_CS_RnW, 0); 
+ res=urj_tap_cable_set_signal((urj_cable_t *)libswdctx->driver->device, URJ_POD_CS_RnW, 0);
  if (res<0) return LIBSWD_ERROR_DRIVER;
  /* void urj_tap_cable_clock (urj_cable_t *cable, int tms, int tdi, int n); */
- urj_tap_cable_clock((urj_cable_t *)libswdctx->driver->device, 1, 1, bits); 
+ urj_tap_cable_clock((urj_cable_t *)libswdctx->driver->device, 1, 1, bits);
 
  return bits;
 }
@@ -173,20 +173,20 @@ int libswd_drv_mosi_trn(libswd_ctx_t *libswdctx, int bits){
  * MISO (Master Input Slave Output) is a SWD Read operation.
  * \param *libswdctx is the swd context to work on.
  * \param bits specify how many clock cycles must be used for TRN.
- * \return number of bits transmitted or negative LIBSWD_ERROR code on failure. 
+ * \return number of bits transmitted or negative LIBSWD_ERROR code on failure.
  */
 int libswd_drv_miso_trn(libswd_ctx_t *libswdctx, int bits){
  if (bits<LIBSWD_TURNROUND_MIN_VAL && bits>LIBSWD_TURNROUND_MAX_VAL)
-  return LIBSWD_ERROR_TURNAROUND; 
+  return LIBSWD_ERROR_TURNAROUND;
 
  static int res;
 
- res=urj_tap_cable_set_signal((urj_cable_t *)libswdctx->driver->device, URJ_POD_CS_RnW, URJ_POD_CS_RnW); 
+ res=urj_tap_cable_set_signal((urj_cable_t *)libswdctx->driver->device, URJ_POD_CS_RnW, URJ_POD_CS_RnW);
  if (res<0) return LIBSWD_ERROR_DRIVER;
 
  /* void urj_tap_cable_clock (urj_cable_t *cable, int tms, int tdi, int n); */
- urj_tap_cable_clock((urj_cable_t *)libswdctx->driver->device, 1, 1, bits); 
- 
+ urj_tap_cable_clock((urj_cable_t *)libswdctx->driver->device, 1, 1, bits);
+
  return bits;
 }
 
@@ -195,7 +195,7 @@ int libswd_drv_miso_trn(libswd_ctx_t *libswdctx, int bits){
  * Set debug level according to UrJTAG settings.
  * \param *libswdctx is the context to work on.
  * \param loglevel is the UrJTAG's lovleve to be transformed into LibSWD one.
- * \return LIBSWD_OK on success, negative LIBSWD_ERROR code on failure. 
+ * \return LIBSWD_OK on success, negative LIBSWD_ERROR code on failure.
  */
 int libswd_log_level_inherit(libswd_ctx_t *libswdctx, int loglevel){
  if (libswdctx==NULL){
@@ -228,7 +228,7 @@ int libswd_log_level_inherit(libswd_ctx_t *libswdctx, int loglevel){
   default:
    new_swdlevel=LIBSWD_LOGLEVEL_NORMAL;
  }
-                                
+
  int res=libswd_log_level_set(libswdctx, new_swdlevel);
  if (res<0) {
   urj_log(URJ_LOG_LEVEL_ERROR, "libswd_log_level_set() failed (%s)\n", libswd_error_string(res));

--- a/src/libswd.h
+++ b/src/libswd.h
@@ -747,8 +747,9 @@ static const libswd_arm_register_t libswd_arm_debug_CPUID[] = {
  { .address=0xE000ED00, .name="ARM Cortex-M3 r2p1",     .default_value=0x412FC231 },
  { .address=0xE000ED00, .name="ARM Cortex-M0 r0p0",     .default_value=0x410CC200 },
  { .address=0xE000ED00, .name="ARM Cortex-M4 r0p1",     .default_value=0x410FC241 },
- { .address=0,          .name=""                  ,     .default_value=0 },
 };
+
+#define LIBSWD_NUM_SUPPORTED_CPUIDS     (sizeof(libswd_arm_debug_CPUID) / sizeof(libswd_arm_debug_CPUID[0]))
 
 typedef struct libswd_debug {
  char initialized;

--- a/src/libswd.h
+++ b/src/libswd.h
@@ -507,7 +507,8 @@ typedef enum {
  LIBSWD_ERROR_CLISYNTAX   =-44, ///< CLI Syntax Error.
  LIBSWD_ERROR_FILE        =-45, ///< File I/O related problem.
  LIBSWD_ERROR_UNSUPPORTED =-46, ///< Target not supported.
- LIBSWD_ERROR_MEMAPACCSIZE=-47  ///< Invalid MEM-AP access size.
+ LIBSWD_ERROR_MEMAPACCSIZE=-47, ///< Invalid MEM-AP access size.
+ LIBSWD_ERROR_MEMAPALIGN  =-48  ///< Invalid MEM-AP allignment.
 } libswd_error_code_t;
 
 /// Do we want autofix errors by default? Not at this point...

--- a/src/libswd.h
+++ b/src/libswd.h
@@ -747,7 +747,7 @@ static const libswd_arm_register_t libswd_arm_debug_CPUID[] = {
  { .address=0xE000ED00, .name="ARM Cortex-M3 r2p1",     .default_value=0x412FC231 }, 
  { .address=0xE000ED00, .name="ARM Cortex-M0 r0p0",     .default_value=0x410CC200 },
  { .address=0xE000ED00, .name="ARM Cortex-M4 r0p1",     .default_value=0x410FC241 },
- 0
+ { .address=0,          .name=""                  ,     .default_value=0 },
 };
 
 typedef struct libswd_debug {

--- a/src/libswd.h
+++ b/src/libswd.h
@@ -828,8 +828,8 @@ int libswd_bin8_print(char *data);
 int libswd_bin32_print(int *data);
 char *libswd_bin8_string(char *data);
 char *libswd_bin32_string(int *data);
-int libswd_bin8_bitswap(unsigned char *buffer, int bitcount);
-int libswd_bin32_bitswap(unsigned int *buffer, int bitcount);
+int libswd_bin8_bitswap(unsigned char *buffer, unsigned int bitcount);
+int libswd_bin32_bitswap(unsigned int *buffer, unsigned int bitcount);
 
 int libswd_cmdq_init(libswd_cmd_t *cmdq);
 libswd_cmd_t* libswd_cmdq_find_head(libswd_cmd_t *cmdq);

--- a/src/libswd.h
+++ b/src/libswd.h
@@ -746,6 +746,7 @@ static const libswd_arm_register_t libswd_arm_debug_CPUID[] = {
  { .address=0xE000ED00, .name="ARM Cortex-M3 r1p2",     .default_value=0x411FC231 },
  { .address=0xE000ED00, .name="ARM Cortex-M3 r2p1",     .default_value=0x412FC231 }, 
  { .address=0xE000ED00, .name="ARM Cortex-M0 r0p0",     .default_value=0x410CC200 },
+ { .address=0xE000ED00, .name="ARM Cortex-M4 r0p1",     .default_value=0x410FC241 },
  0
 };
 

--- a/src/libswd.h
+++ b/src/libswd.h
@@ -743,10 +743,10 @@ static const libswd_arm_register_t libswd_arm_debug_CortexM3_SCS_ComponentID[] =
 };
 
 static const libswd_arm_register_t libswd_arm_debug_CPUID[] = {
- { .address=0xE000ED00, .name="ARM Cortex-M3 r1p2",     .default_value=0x411FC231 },
- { .address=0xE000ED00, .name="ARM Cortex-M3 r2p1",     .default_value=0x412FC231 },
- { .address=0xE000ED00, .name="ARM Cortex-M0 r0p0",     .default_value=0x410CC200 },
- { .address=0xE000ED00, .name="ARM Cortex-M4 r0p1",     .default_value=0x410FC241 },
+ { .name="ARM Cortex-M3 r1p2",     .default_value=0x411FC231 },
+ { .name="ARM Cortex-M3 r2p1",     .default_value=0x412FC231 },
+ { .name="ARM Cortex-M0 r0p0",     .default_value=0x410CC200 },
+ { .name="ARM Cortex-M4 r0p1",     .default_value=0x410FC241 },
 };
 
 #define LIBSWD_NUM_SUPPORTED_CPUIDS     (sizeof(libswd_arm_debug_CPUID) / sizeof(libswd_arm_debug_CPUID[0]))
@@ -758,6 +758,7 @@ typedef struct libswd_debug {
  libswd_arm_register_t *romtable;
 } libswd_debug_t;
 
+#define LIBSWD_ARM_DEBUG_CPUID_ADDR  0xE000ED00
 #define LIBSWD_ARM_DEBUG_DFSR_ADDR   0xE000ED30
 #define LIBSWD_ARM_DEBUG_DHCSR_ADDR  0xE000EDF0
 #define LIBSWD_ARM_DEBUG_DCRSR_ADDR  0xE000EDF4

--- a/src/libswd.h
+++ b/src/libswd.h
@@ -746,6 +746,7 @@ static const libswd_arm_register_t libswd_arm_debug_CPUID[] = {
  { .name="ARM Cortex-M3 r1p2",     .default_value=0x411FC231 },
  { .name="ARM Cortex-M3 r2p1",     .default_value=0x412FC231 },
  { .name="ARM Cortex-M0 r0p0",     .default_value=0x410CC200 },
+ { .name="ARM Cortex-M0+ r0p0",    .default_value=0x410CC600 },
  { .name="ARM Cortex-M4 r0p1",     .default_value=0x410FC241 },
 };
 

--- a/src/libswd_app.c
+++ b/src/libswd_app.c
@@ -1249,7 +1249,7 @@ int libswdapp_interface_ftdi_transfer_bits(libswdapp_context_t *libswdappctx, in
  {
   // Try to pack as many bits into bytes for better performance.
   bytes=bits/8;
-  bytes--;		              // MPSSE starts counting bytes from 0.
+  bytes--;                        // MPSSE starts counting bytes from 0.
   buf[0] = (nLSBfirst)?0x31:0x39; // Clock Bytes In and Out LSb or MSb first.
   buf[1] = (char)bytes&0x0ff;
   buf[2] = (char)((bytes>>8)&0x0ff);
@@ -1295,7 +1295,7 @@ int libswdapp_interface_ftdi_transfer_bits(libswdapp_context_t *libswdappctx, in
  for (bit=bytes*8;bit<bits;bit++)
  {
   buf[3*bit+0] = (nLSBfirst)?0x33:0x3b; // Clock Bits In and Out LSb or MSb first.
-  buf[3*bit+1] = 0;				     // One bit per element.
+  buf[3*bit+1] = 0;                     // One bit per element.
   buf[3*bit+2] = mosidata[bit]?0xff:0;  // Take data from supplied array.
  }
  bytes_written = ftdi_write_data(ftdictx,buf,3*(bits-(bytes*8)));
@@ -1353,7 +1353,7 @@ int libswdapp_interface_ftdi_transfer_bytes(libswdapp_context_t *libswdappctx, i
   return LIBSWD_ERROR_DRIVER;
  }
 
- bytes--;		                  // MPSSE starts counting bytes from 0.
+ bytes--;                        // MPSSE starts counting bytes from 0.
  buf[0] = (nLSBfirst)?0x31:0x39; // Clock Bytes In and Out MSb or LSb first.
  buf[1] = (char)bytes&0x0ff;
  buf[2] = (char)((bytes>>8)&0x0ff);

--- a/src/libswd_app.c
+++ b/src/libswd_app.c
@@ -149,7 +149,7 @@ int main(int argc, char **argv){
     break;
    case 'l':
     libswdappctx->loglevel=atol(optarg);
-    break; 
+    break;
    case 'v':
     libswdappctx->interface->vid_forced=strtol(optarg, (char**)NULL, 16);
     break;
@@ -198,7 +198,7 @@ int main(int argc, char **argv){
  if (retval!=LIBSWD_OK) return retval;
  // Store program Context for use with interface drivers.
  libswdappctx->libswdctx->driver->ctx=libswdappctx;
- // Store interface structure in libswd driver. 
+ // Store interface structure in libswd driver.
  libswdappctx->libswdctx->driver->interface=libswdappctx->interface;
 
  // Setup the Readline
@@ -231,7 +231,7 @@ int main(int argc, char **argv){
     libswdapp_print_usage();
    }
    retval=libswd_cli(libswdappctx->libswdctx, cmd);
-   if (retval!=LIBSWD_OK) if (retval!=LIBSWD_ERROR_CLISYNTAX) goto quit; 
+   if (retval!=LIBSWD_OK) if (retval!=LIBSWD_ERROR_CLISYNTAX) goto quit;
   }
  }
 
@@ -254,7 +254,7 @@ int libswdapp_handle_command_flash_usage(void){
  printf("  [r]ead <filename> <count>\n");
  printf("  [w]rite filename\n");
  printf("  [m]ass[e]rase\n");
- printf("  Note: Target will be detected automaticaly to verify flash support.\n"); 
+ printf("  Note: Target will be detected automaticaly to verify flash support.\n");
  printf("\n");
  return LIBSWD_OK;
 }
@@ -276,7 +276,7 @@ int libswdapp_handle_command_flash(libswdapp_context_t *libswdappctx, char *comm
  // Initialize the MEM-AP and DAP if not yet initialized...
  if (!libswdctx->log.memap.initialized)
  {
-  retval=libswd_memap_init(libswdctx, LIBSWD_OPERATION_EXECUTE); 
+  retval=libswd_memap_init(libswdctx, LIBSWD_OPERATION_EXECUTE);
   if (retval<0) goto libswdapp_handle_command_flash_error;
  }
 
@@ -287,7 +287,7 @@ int libswdapp_handle_command_flash(libswdapp_context_t *libswdappctx, char *comm
  addrstart=flash_memmap.page_start;
  count=(flash_memmap.page_end-flash_memmap.page_start);
 
- // Check if target is halted, halt if necessary. 
+ // Check if target is halted, halt if necessary.
  if (!libswd_debug_is_halted(libswdctx, LIBSWD_OPERATION_EXECUTE))
  {
   retval=libswd_debug_halt(libswdctx, LIBSWD_OPERATION_EXECUTE);
@@ -323,14 +323,14 @@ int libswdapp_handle_command_flash(libswdapp_context_t *libswdappctx, char *comm
     retval=LIBSWD_ERROR_CLISYNTAX;
     goto libswdapp_handle_command_flash_error;
    }
-  } 
+  }
   // Take care of proper memory (re)allocation.
   if (libswdctx->membuf.data) free(libswdctx->membuf.data);
   libswdctx->membuf.data=(unsigned char*)malloc(count*sizeof(char));
   if (!libswdctx->membuf.data)
   {
    libswdctx->membuf.size=0;
-   libswd_log(libswdctx, LIBSWD_ERROR_OUTOFMEM, 
+   libswd_log(libswdctx, LIBSWD_ERROR_OUTOFMEM,
               "FLASH ERROR: Cannot (re)allocate memory buffer!\n");
    return LIBSWD_ERROR_OUTOFMEM;
   } else memset((void*)libswdctx->membuf.data, 0xFF, count);
@@ -355,7 +355,7 @@ int libswdapp_handle_command_flash(libswdapp_context_t *libswdappctx, char *comm
    retval=fwrite(libswdctx->membuf.data, sizeof(char), count, fp);
    if (!retval)
    {
-    libswd_log(libswdctx, LIBSWD_LOGLEVEL_ERROR, 
+    libswd_log(libswdctx, LIBSWD_LOGLEVEL_ERROR,
                "FLASH ERROR: Cannot write to data file '%s' (%s)!\n",
                filename, strerror(errno) );
     goto libswdapp_handle_command_flash_error;
@@ -363,7 +363,7 @@ int libswdapp_handle_command_flash(libswdapp_context_t *libswdappctx, char *comm
    i=fclose(fp);
    if (i)
    {
-    libswd_log(libswdctx, LIBSWD_LOGLEVEL_ERROR, 
+    libswd_log(libswdctx, LIBSWD_LOGLEVEL_ERROR,
                "FLASH ERROR: Cannot close data file '%s' (%s)!\n",
                filename, strerror(errno) );
     goto libswdapp_handle_command_flash_error;
@@ -413,7 +413,7 @@ int libswdapp_handle_command_flash(libswdapp_context_t *libswdappctx, char *comm
   if (!i)
   {
    retval=LIBSWD_ERROR_MAXRETRY;
-   goto libswdapp_handle_command_flash_error; 
+   goto libswdapp_handle_command_flash_error;
   }
   //Set MER bit in FLASH_CR
   retval=libswd_memap_read_int_32(libswdctx, LIBSWD_OPERATION_EXECUTE, flash_memmap.FLASH_CR_ADDR, 1, &data);
@@ -434,7 +434,7 @@ int libswdapp_handle_command_flash(libswdapp_context_t *libswdappctx, char *comm
   if (!i)
   {
    retval=LIBSWD_ERROR_MAXRETRY;
-   goto libswdapp_handle_command_flash_error; 
+   goto libswdapp_handle_command_flash_error;
   }
   libswd_log(libswdctx, LIBSWD_LOGLEVEL_NORMAL, "FLASH MASS-ERASE OK!\n");
  }
@@ -472,7 +472,7 @@ int libswdapp_handle_command_flash(libswdapp_context_t *libswdappctx, char *comm
     libswd_log(libswdctx, LIBSWD_LOGLEVEL_ERROR,
                "FLASH ERROR: File (0x%X) won't fit in memory (0x%X)!\n",
                ftell(fp), count);
-    retval=LIBSWD_ERROR_OUTOFMEM; 
+    retval=LIBSWD_ERROR_OUTOFMEM;
     goto libswdapp_handle_command_flash_error;
    }
    // Allocate memory for file content.
@@ -491,7 +491,7 @@ int libswdapp_handle_command_flash(libswdapp_context_t *libswdappctx, char *comm
    retval=fread(libswdctx->membuf.data, sizeof(char), libswdctx->membuf.size, fp);
    if (!retval)
    {
-    libswd_log(libswdctx, LIBSWD_LOGLEVEL_ERROR, 
+    libswd_log(libswdctx, LIBSWD_LOGLEVEL_ERROR,
                "FLASH ERROR: Cannot load data from '%s' file (%s)!\n",
                filename, strerror(errno) );
     retval=LIBSWD_ERROR_FILE;
@@ -500,7 +500,7 @@ libswdapp_handle_command_flash_file_load_error:
    retval=fclose(fp);
    if (retval)
    {
-    libswd_log(libswdctx, LIBSWD_LOGLEVEL_ERROR, 
+    libswd_log(libswdctx, LIBSWD_LOGLEVEL_ERROR,
                "FLASH ERROR: libswd_cli(): Cannot close data file '%s' (%s)!\n",
                filename, strerror(errno) );
     retval=LIBSWD_ERROR_FILE;
@@ -513,7 +513,7 @@ libswdapp_handle_command_flash_file_load_ok:
    count=libswdctx->membuf.size;
    // At this point data are in membuf, sent them to MEM-AP.
 
-   // FLASH WRITE 
+   // FLASH WRITE
    // Unlock the Flash Controller.
    libswd_log(libswdctx, LIBSWD_LOGLEVEL_INFO, "FLASH: Unlocking STM32 FPEC...\n");
    data=LIBSWDAPP_FLASH_STM32F1_FLASH_KEYR_KEY1_VAL;
@@ -534,7 +534,7 @@ libswdapp_handle_command_flash_file_load_ok:
    if (!i)
    {
     retval=LIBSWD_ERROR_MAXRETRY;
-    goto libswdapp_handle_command_flash_error; 
+    goto libswdapp_handle_command_flash_error;
    }
    //Set MER bit in FLASH_CR
    retval=libswd_memap_read_int_32(libswdctx, LIBSWD_OPERATION_EXECUTE, flash_memmap.FLASH_CR_ADDR, 1, &data);
@@ -555,7 +555,7 @@ libswdapp_handle_command_flash_file_load_ok:
    if (!i)
    {
     retval=LIBSWD_ERROR_MAXRETRY;
-    goto libswdapp_handle_command_flash_error; 
+    goto libswdapp_handle_command_flash_error;
    }
    // Perform Flash write.
    libswd_log(libswdctx, LIBSWD_LOGLEVEL_NORMAL, "FLASH: Performing Flash Write...\n");
@@ -568,7 +568,7 @@ libswdapp_handle_command_flash_file_load_ok:
    int accsize=4;
    addr=flash_memmap.page_start;
    retval=libswd_memap_write_char_csw(libswdctx, LIBSWD_OPERATION_EXECUTE, addr, count, (char *)libswdctx->membuf.data, LIBSWD_MEMAP_CSW_SIZE_16BIT|LIBSWD_MEMAP_CSW_ADDRINC_PACKED);
-    if (retval<0) goto libswdapp_handle_command_flash_error; 
+    if (retval<0) goto libswdapp_handle_command_flash_error;
    // Print out the data.
    for (i=0; i<libswdctx->membuf.size; i=i+16)
    {
@@ -695,7 +695,7 @@ int libswdapp_handle_command_signal(libswdapp_context_t *libswdappctx, char *cmd
      libswd_log(libswdctx, LIBSWD_LOGLEVEL_WARNING,
                 "WARNING: Cannot add '%s' signal with '%x' mask!\n", signamep, sigmaskp, sigmask );
     continue;
-   } 
+   }
   }
   // Check if signal read/write, handle if necessary.
   signamep=strsep(&cmdp,"=");
@@ -706,7 +706,7 @@ int libswdapp_handle_command_signal(libswdapp_context_t *libswdappctx, char *cmd
     sigval=~0;
    else if (!strncmp(sigvalp,"lo",2))
     sigval=0;
-   else 
+   else
    {
     errno=LIBSWD_OK;
     sigval=strtol(sigvalp,NULL,16);
@@ -724,7 +724,7 @@ int libswdapp_handle_command_signal(libswdapp_context_t *libswdappctx, char *cmd
    libswd_log(libswdctx, LIBSWD_LOGLEVEL_WARNING,
               "WARNING: Signal '%s' not found!\n", signamep );
    continue;
-  } 
+  }
   if (signamep && sigvalp)
   {
    retval=libswdappctx->interface->bitbang(libswdappctx, sig->mask, 0, &sigval);
@@ -752,14 +752,14 @@ int libswdapp_handle_command_signal(libswdapp_context_t *libswdappctx, char *cmd
  }
  free(command);
  return LIBSWD_OK;
-  
+
 libswdapp_handle_command_signal_error:
   free(command);
   libswd_log(libswdctx, LIBSWD_LOGLEVEL_ERROR,
              "ERROR: Syntax Error, see '?' or '[s]ignal' for more information...\n" );
   return LIBSWD_ERROR_CLISYNTAX;
 }
- 
+
 
 /** It will prepare interface for use or fail.
  * If an interface is already configured, it will check if requested interface
@@ -781,7 +781,7 @@ int libswdapp_handle_command_interface_init(libswdapp_context_t *libswdappctx, c
  }
 
  // Verify selected interface name or try the dedault.
- if (!libswdappctx->interface->name[0]) 
+ if (!libswdappctx->interface->name[0])
  {
   libswd_log(libswdctx, LIBSWD_LOGLEVEL_NORMAL,
              "Trying the default interface '%s'...\n",
@@ -821,7 +821,7 @@ int libswdapp_handle_command_interface_init(libswdapp_context_t *libswdappctx, c
  if (libswdappctx->interface->ctx!=NULL && libswdappctx->interface->deinit)
   libswdappctx->interface->deinit(libswdappctx);
  if (libswdappctx->interface->signal)
-  libswdapp_interface_signal_del(libswdappctx, "*"); 
+  libswdapp_interface_signal_del(libswdappctx, "*");
  libswdappctx->interface->description[0]=0;
  libswdappctx->interface->init=NULL;
  libswdappctx->interface->deinit=NULL;
@@ -866,7 +866,7 @@ int libswdapp_handle_command_interface_init(libswdapp_context_t *libswdappctx, c
   return retval;
  }
 
- libswdappctx->interface->initialized=1; 
+ libswdappctx->interface->initialized=1;
  return retval;
 }
 
@@ -906,7 +906,7 @@ libswdapp_interface_signal_t *libswdapp_interface_signal_find(libswdapp_context_
 /** Add new signal to the interface.
  * Signal will be allocated in memory with provided name and pin mask.
  * Note: Signal definition may take place before interface is ready to operate,
- * therefore value will be not assigned at time of signal creation. 
+ * therefore value will be not assigned at time of signal creation.
  * Signal value can be set with appropriate 'bitbang' call.
  * The default value for new signal equals provided mask to maintain Hi-Z.
  *
@@ -922,7 +922,7 @@ int libswdapp_interface_signal_add(libswdapp_context_t *libswdappctx, char *name
 
  libswd_ctx_t *libswdctx=(libswd_ctx_t*)libswdappctx->libswdctx;
 
- // Check if name is correct string. 
+ // Check if name is correct string.
  if (!name || *name==' ')
  {
   libswd_log(libswdctx, LIBSWD_LOGLEVEL_ERROR,
@@ -956,7 +956,7 @@ int libswdapp_interface_signal_add(libswdapp_context_t *libswdappctx, char *name
  if (!newsignal->name)
    goto libswdapp_interface_signal_add_end;
 
- // Initialize structure data and return or break on error. 
+ // Initialize structure data and return or break on error.
  if (!strncpy(newsignal->name, name, snlen))
  {
   libswd_log(libswdctx, LIBSWD_LOGLEVEL_WARNING,
@@ -1017,11 +1017,11 @@ int libswdapp_interface_signal_del(libswdapp_context_t *libswdappctx, char *name
   {
    libswd_log(libswdctx, LIBSWD_LOGLEVEL_INFO,
               "INFO: Removing Interface Signal '%s'...", delsig->name );
-   free(delsig->name); 
+   free(delsig->name);
    free(delsig);
    libswd_log(libswdctx, LIBSWD_LOGLEVEL_INFO, "OK\n");
   }
-  libswdappctx->interface->signal=NULL; 
+  libswdappctx->interface->signal=NULL;
   return LIBSWD_OK;
  }
  // look for the signal name on the list.
@@ -1111,12 +1111,12 @@ int libswdapp_interface_ftdi_bitbang(libswdapp_context_t *libswdappctx, unsigned
  unsigned char  buf[3];
  int retval, retry;
  int bytes_written, bytes_read;
- unsigned int vall=0, valh=0, gpioval=0, gpiodir=0; 
+ unsigned int vall=0, valh=0, gpioval=0, gpiodir=0;
  struct ftdi_context *ftdictx=(struct ftdi_context*)libswdappctx->interface->ctx;
 
  if (!GETnSET) {
   // We will SET port pin values for selected bitmask.
-  // Modify our pins value, but remember about other pins and their previous value. 
+  // Modify our pins value, but remember about other pins and their previous value.
   gpioval = (libswdappctx->interface->gpioval & ~bitmask) | (*value & bitmask);
   // Modify our pins direction, but remember about other pins and their previous direction.
   gpiodir = libswdappctx->interface->gpiodir | bitmask;
@@ -1324,7 +1324,7 @@ int libswdapp_interface_ftdi_transfer_bits(libswdapp_context_t *libswdappctx, in
  {
   misodata[bit]=(buf[bit]&(nLSBfirst?0x01:0x80))?1:0;
   // USE THIS FOR WIRE-LEVEL DEBUG */
-  //printf("\n===TRANSFER: Bit %d read 0x%02X written 0x%02X\n", bit, misodata[bit], mosidata[bit]); 
+  //printf("\n===TRANSFER: Bit %d read 0x%02X written 0x%02X\n", bit, misodata[bit], mosidata[bit]);
  }
  return bit;
 }
@@ -1435,8 +1435,8 @@ int libswdapp_interface_ftdi_init(libswdapp_context_t *libswdappctx)
     if (libswdappctx->loglevel)
      libswd_log(libswdctx, LIBSWD_LOGLEVEL_NORMAL, "OK\n");
    }
-   else if (libswdappctx->loglevel) 
-    libswd_log(libswdctx, LIBSWD_LOGLEVEL_NORMAL, "OK (ChipId=%X)\n", chipid); 
+   else if (libswdappctx->loglevel)
+    libswd_log(libswdctx, LIBSWD_LOGLEVEL_NORMAL, "OK (ChipId=%X)\n", chipid);
   } else if (libswdappctx->loglevel)
      libswd_log(libswdctx, LIBSWD_LOGLEVEL_NORMAL, "OK\n");
  }
@@ -1484,7 +1484,7 @@ int libswdapp_interface_ftdi_init(libswdapp_context_t *libswdappctx)
              "ERROR: Cannot set bitmode BITMODE_MPSSE for '%s' interface!\n",
              libswdappctx->interface->name );
   return LIBSWD_ERROR_DRIVER;
- } 
+ }
  // Set large chunksize for faster transfers of large data.
  retval=ftdi_write_data_set_chunksize(ftdictx, libswdappctx->interface->chunksize);
   if (retval<0)
@@ -1494,7 +1494,7 @@ int libswdapp_interface_ftdi_init(libswdapp_context_t *libswdappctx)
              libswdappctx->interface->chunksize,
              libswdappctx->interface->name );
   return LIBSWD_ERROR_DRIVER;
- } 
+ }
  retval=ftdi_read_data_set_chunksize(ftdictx, libswdappctx->interface->chunksize);
   if (retval<0)
  {
@@ -1503,7 +1503,7 @@ int libswdapp_interface_ftdi_init(libswdapp_context_t *libswdappctx)
              libswdappctx->interface->chunksize,
              libswdappctx->interface->name );
   return LIBSWD_ERROR_DRIVER;
- } 
+ }
  // Set default interface speed/frequency
  libswdapp_interface_ftdi_set_freq(libswdappctx, libswdappctx->interface->frequency);
 
@@ -1527,7 +1527,7 @@ int libswdapp_interface_ftdi_init(libswdapp_context_t *libswdappctx)
  * Warning: Passing zero as freq parameter means maximum available frequency.
  * \param *libswdappctx pointer to the LibSWD Application Context.
  * \param freq desired frequency in Hz (0 means maximum frequency).
- * \return LIBSWD_OK on success, negative error code otherwise. 
+ * \return LIBSWD_OK on success, negative error code otherwise.
  */
 int libswdapp_interface_ftdi_set_freq(libswdapp_context_t *libswdappctx, int freq)
 {
@@ -1557,7 +1557,7 @@ int libswdapp_interface_ftdi_set_freq(libswdapp_context_t *libswdappctx, int fre
  libswdappctx->interface->frequency=freq;
  libswd_log(libswdappctx->libswdctx, LIBSWD_LOGLEVEL_INFO,
             "INFO: Interface frequency set to %d\n", freq);
- return LIBSWD_OK; 
+ return LIBSWD_OK;
 }
 
 
@@ -1574,7 +1574,7 @@ int libswdapp_interface_ftdi_init_ktlink(libswdapp_context_t *libswdappctx)
 
  libswd_log(libswdappctx->libswdctx, LIBSWD_LOGLEVEL_INFO,
             "INFO: Disabling CLK/5 (set max CLK=30MHz)...");
- buf[0]=0x8A; 
+ buf[0]=0x8A;
  retval=ftdi_write_data(ftdictx, buf, 1);
  if (retval<0 || retval!=1)
  {
@@ -1583,7 +1583,7 @@ int libswdapp_interface_ftdi_init_ktlink(libswdapp_context_t *libswdappctx)
   libswd_log(libswdappctx->libswdctx, LIBSWD_LOGLEVEL_ERROR,
              "ERROR: Cannot switch off clock divisor!\n");
   return retval;
- } 
+ }
  libswdappctx->interface->maxfrequency=30000000;
  libswd_log(libswdappctx->libswdctx, LIBSWD_LOGLEVEL_INFO, "OK\n");
 
@@ -1596,10 +1596,10 @@ int libswdapp_interface_ftdi_deinit(libswdapp_context_t *libswdappctx)
 {
  unsigned int dir=0,val;
  struct ftdi_context *ftdictx=(struct ftdi_context*)libswdappctx->interface->ctx;
- libswdappctx->interface->bitbang(libswdappctx, dir, 1, &val); 
+ libswdappctx->interface->bitbang(libswdappctx, dir, 1, &val);
  ftdi_deinit(ftdictx);
  return LIBSWD_OK;
-} 
+}
 
 
 

--- a/src/libswd_app.h
+++ b/src/libswd_app.h
@@ -60,7 +60,7 @@ typedef struct libswdapp_interface_signal {
 
 typedef struct libswdapp_context {
  libswd_ctx_t *libswdctx;
- struct libswdapp_interface *interface; 
+ struct libswdapp_interface *interface;
  int loglevel;
  int retval;
 } libswdapp_context_t;
@@ -163,9 +163,9 @@ static const libswdapp_interface_config_t libswdapp_interface_configs[] = {
   .set_freq       = libswdapp_interface_ftdi_set_freq,
   .bitbang        = libswdapp_interface_ftdi_bitbang,
   .transfer_bits  = libswdapp_interface_ftdi_transfer_bits,
-  .transfer_bytes = libswdapp_interface_ftdi_transfer_bytes, 
+  .transfer_bytes = libswdapp_interface_ftdi_transfer_bytes,
   .vid            = 0x0403,
-  .pid            = 0xbbe2, 
+  .pid            = 0xbbe2,
   .latency        = 1,
   .maxfrequency   = 30000000,
   .frequency      = 1000000,
@@ -180,9 +180,9 @@ static const libswdapp_interface_config_t libswdapp_interface_configs[] = {
   .set_freq       = libswdapp_interface_aftdi_set_freq,
   .bitbang        = libswdapp_interface_aftdi_bitbang,
   .transfer_bits  = libswdapp_interface_aftdi_transfer_bits,
-  .transfer_bytes = libswdapp_interface_aftdi_transfer_bytes, 
+  .transfer_bytes = libswdapp_interface_aftdi_transfer_bytes,
   .vid            = 0x0403,
-  .pid            = 0xbbe2, 
+  .pid            = 0xbbe2,
   .latency        = 1,
   .maxfrequency   = 30000000,
   .frequency      = 1000000,
@@ -296,7 +296,7 @@ static const libswdapp_flash_stm32f1_memmap_t *libswdapp_flash_stm32f1_devices[]
  &libswdapp_flash_stm321f_mediumdensity,
  &libswdapp_flash_stm321f_highdensity,
  &libswdapp_flash_stm321f_connectivityline,
- NULL 
+ NULL
 };
 
 #define LIBSWDAPP_FLASH_STM32F1_FLASH_OBR_RDPRT_VAL 0x000000A5

--- a/src/libswd_app.h
+++ b/src/libswd_app.h
@@ -40,8 +40,8 @@
 #include <libswd.h>
 #include <ftdi.h>
 
-#define LIBSWDAPP_INTERFACE_SIGNAL_NAME_MINLEN	1
-#define LIBSWDAPP_INTERFACE_SIGNAL_NAME_MAXLEN	32
+#define LIBSWDAPP_INTERFACE_SIGNAL_NAME_MINLEN    1
+#define LIBSWDAPP_INTERFACE_SIGNAL_NAME_MAXLEN    32
 #define LIBSWDAPP_INTERFACE_NAME_MAXLEN           32
 #define LIBSWDAPP_INTERFACE_CONFIG_NAME_MAXLEN    32
 #define LIBSWDAPP_INTERFACE_VID_DEFAULT           0x0403
@@ -52,10 +52,10 @@
 #define LIBSWDAPP_CLI_HISTORY_MAXLEN  1024
 
 typedef struct libswdapp_interface_signal {
-	char *name;                         /// Signal name string.
-	unsigned int mask;                  /// Mask value for selected signal.
-	int value;                          /// Cached signal value.
-	struct libswdapp_interface_signal *next; /// Next signal on the list.
+ char *name;                         /// Signal name string.
+ unsigned int mask;                  /// Mask value for selected signal.
+ int value;                          /// Cached signal value.
+ struct libswdapp_interface_signal *next; /// Next signal on the list.
 } libswdapp_interface_signal_t;
 
 typedef struct libswdapp_context {
@@ -108,11 +108,11 @@ typedef struct libswdapp_interface_config {
 } libswdapp_interface_config_t;
 
 typedef enum libswdapp_interface_operation {
-	OOCD_INTERFACE_SIGNAL_OPERATION_UNDEFINED = 0,
-	OOCD_INTERFACE_SIGNAL_OPERATION_READ,
-	OOCD_INTERFACE_SIGNAL_OPERATION_WRITE,
-	OOCD_INTERFACE_SIGNAL_OPERATION_SET,
-	OOCD_INTERFACE_SIGNAL_OPERATION_CLEAR
+ OOCD_INTERFACE_SIGNAL_OPERATION_UNDEFINED = 0,
+ OOCD_INTERFACE_SIGNAL_OPERATION_READ,
+ OOCD_INTERFACE_SIGNAL_OPERATION_WRITE,
+ OOCD_INTERFACE_SIGNAL_OPERATION_SET,
+ OOCD_INTERFACE_SIGNAL_OPERATION_CLEAR
 } libswdapp_interface_operation_t;
 
 

--- a/src/libswd_bin.c
+++ b/src/libswd_bin.c
@@ -66,7 +66,7 @@ int libswd_bin32_parity_even(int *data, char *parity){
  int i;
  unsigned int test=*data;
  *parity=0;
- for (i=0;i<32;i++) *parity ^= ((test>>i)&1); 
+ for (i=0;i<32;i++) *parity ^= ((test>>i)&1);
  if (*parity<0 || *parity>1) return LIBSWD_ERROR_PARITY;
  return (int)*parity;
 }
@@ -78,7 +78,7 @@ int libswd_bin32_parity_even(int *data, char *parity){
  */
 int libswd_bin8_print(char *data){
  unsigned char i, bits=*data;
- for (i=0;i<8;i++) putchar(((bits<<i)&0x80)?'1':'0'); 
+ for (i=0;i<8;i++) putchar(((bits<<i)&0x80)?'1':'0');
  return i;
 }
 
@@ -101,7 +101,7 @@ int libswd_bin32_print(int *data){
 char *libswd_bin8_string(char *data){
  static char string[9]; string[8]=0;
  unsigned char i, bits=*data;
- for (i=0;i<8;i++) string[7-i]=(bits&(1<<i))?'1':'0'; 
+ for (i=0;i<8;i++) string[7-i]=(bits&(1<<i))?'1':'0';
  return string;
 }
 
@@ -118,12 +118,12 @@ char *libswd_bin32_string(int *data){
 }
 
 /**
- * Bit swap helper function that reverse bit order in char *buffer. 
+ * Bit swap helper function that reverse bit order in char *buffer.
  * Most Significant Bit becomes Least Significant Bit.
  * It is possible to  swap only n-bits from char (8-bit) *buffer.
  * \param *buffer unsigned char (8-bit) data pointer.
  * \param bitcount how many bits to swap.
- * \return swapped bit count (positive) or error code (negative). 
+ * \return swapped bit count (positive) or error code (negative).
  */
 int libswd_bin8_bitswap(unsigned char *buffer, int bitcount){
  if (buffer==NULL) return LIBSWD_ERROR_NULLPOINTER;
@@ -133,7 +133,7 @@ int libswd_bin8_bitswap(unsigned char *buffer, int bitcount){
  printf("|LIBSWD_DEBUG: libswd_bin8_bitswap(%02X, %d);\n", *buffer, bitcount);
  #endif
  for (bit=0;bit<bitcount;bit++) {
-  result=(result<<1)|(((*buffer>>bit)&1)?1:0); 
+  result=(result<<1)|(((*buffer>>bit)&1)?1:0);
   #ifdef __SWDDEBUG__
   printf("|LIBSWD_DEBUG: libswd_bin8_bitswap: in=%02X out=%02X bit=%d\n", *buffer, result, bit);
   #endif
@@ -143,12 +143,12 @@ int libswd_bin8_bitswap(unsigned char *buffer, int bitcount){
 }
 
 /**
- * Bit swap helper function that reverse bit order in int *buffer. 
+ * Bit swap helper function that reverse bit order in int *buffer.
  * Most Significant Bit becomes Least Significant Bit.
  * It is possible to  swap only n-bits from int (32-bit) *buffer.
  * \param *buffer unsigned char (32-bit) data pointer.
  * \param bitcount how many bits to swap.
- * \return swapped bit count (positive) or error code (negative). 
+ * \return swapped bit count (positive) or error code (negative).
  */
 int libswd_bin32_bitswap(unsigned int *buffer, int bitcount){
  if (buffer==NULL) return LIBSWD_ERROR_NULLPOINTER;
@@ -158,7 +158,7 @@ int libswd_bin32_bitswap(unsigned int *buffer, int bitcount){
  printf("|LIBSWD_DEBUG: libswd_bin32_bitswap(%08X, %d);\n", *buffer, bitcount);
  #endif
  for (bit=0;bit<bitcount;bit++) {
-  result=(result<<1)|(((*buffer>>bit)&1)?1:0); 
+  result=(result<<1)|(((*buffer>>bit)&1)?1:0);
   #ifdef __SWDDEBUG__
   printf("|LIBSWD_DEBUG: libswd_bin32_bitswap: in=%08X out=%08X bit=%d\n", *buffer, result, bit);
   #endif

--- a/src/libswd_bin.c
+++ b/src/libswd_bin.c
@@ -125,7 +125,7 @@ char *libswd_bin32_string(int *data){
  * \param bitcount how many bits to swap.
  * \return swapped bit count (positive) or error code (negative).
  */
-int libswd_bin8_bitswap(unsigned char *buffer, int bitcount){
+int libswd_bin8_bitswap(unsigned char *buffer, unsigned int bitcount){
  if (buffer==NULL) return LIBSWD_ERROR_NULLPOINTER;
  if (bitcount>8) return LIBSWD_ERROR_PARAM;
  unsigned char bit, result=0; //res must be unsigned for proper shifting result
@@ -150,7 +150,7 @@ int libswd_bin8_bitswap(unsigned char *buffer, int bitcount){
  * \param bitcount how many bits to swap.
  * \return swapped bit count (positive) or error code (negative).
  */
-int libswd_bin32_bitswap(unsigned int *buffer, int bitcount){
+int libswd_bin32_bitswap(unsigned int *buffer, unsigned int bitcount){
  if (buffer==NULL) return LIBSWD_ERROR_NULLPOINTER;
  if (bitcount>32) return LIBSWD_ERROR_PARAM;
  unsigned int bit, result=0; //res must be unsigned for proper shifting result

--- a/src/libswd_bus.c
+++ b/src/libswd_bus.c
@@ -41,7 +41,7 @@
  * These functions generate payloads and queue up all elements/commands
  * necessary to perform requested operations on the SWD bus. Depending
  * on "operation" type, elements can be only enqueued on the queue (operation ==
- * LIBSWD_OPERATION_ENQUEUE) or queued and then flushed into hardware driver 
+ * LIBSWD_OPERATION_ENQUEUE) or queued and then flushed into hardware driver
  * (operation == LIBSWD_OPERATION_EXECUTE) for immediate effect on the target.
  * Other operations are not allowed for these functions and will produce error.
  * This group of functions is intelligent, so they will react on errors, when
@@ -67,7 +67,7 @@ int libswd_bus_setdir_mosi(libswd_ctx_t *libswdctx){
  }
  return cmdcnt;
 }
- 
+
 /** Append command queue with TRN READ/MISO, if previous command was WRITE/MOSI.
  * \param *libswdctx swd context pointer.
  * \return number of elements appended, or LIBSWD_ERROR_CODE on failure.
@@ -112,7 +112,7 @@ int libswd_bus_write_request_raw
  qcmdcnt+=res;
 
  if (operation==LIBSWD_OPERATION_ENQUEUE){
-  return qcmdcnt; 
+  return qcmdcnt;
  } else if (operation==LIBSWD_OPERATION_EXECUTE){
   res=libswd_cmdq_flush(libswdctx, &libswdctx->cmdq, operation);
   if (res<0) return res;
@@ -142,7 +142,7 @@ int libswd_bus_write_request
  int res, qcmdcnt=0, tcmdcnt=0;
  char request;
 
- /* Generate request bitstream. */ 
+ /* Generate request bitstream. */
  res=libswd_bitgen8_request(libswdctx, APnDP, RnW, addr, &request);
  if (res<0) return res;
 
@@ -157,7 +157,7 @@ int libswd_bus_write_request
  qcmdcnt+=res;
 
  if (operation==LIBSWD_OPERATION_ENQUEUE){
-  return qcmdcnt; 
+  return qcmdcnt;
  } else if (operation==LIBSWD_OPERATION_EXECUTE){
   res=libswd_cmdq_flush(libswdctx, &libswdctx->cmdq, operation);
   if (res<0) return res;
@@ -168,9 +168,9 @@ int libswd_bus_write_request
 
 /** Perform ACK read into *ack and verify received data.
  * \param *libswdctx swd context pointer.
- * \param operation type of action to perform with generated request. 
+ * \param operation type of action to perform with generated request.
  * \param *ack pointer to the result location.
- * \return number of commands processed, or LIBSWD_ERROR_CODE on failure. 
+ * \return number of commands processed, or LIBSWD_ERROR_CODE on failure.
  */
 int libswd_bus_read_ack(libswd_ctx_t *libswdctx, libswd_operation_t operation, char **ack){
  if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
@@ -218,13 +218,13 @@ int libswd_bus_read_ack(libswd_ctx_t *libswdctx, libswd_operation_t operation, c
  /* Search backward for ACK command on the queue (ack we have just appended). */
  while (tmpcmdq->cmdtype!=LIBSWD_CMDTYPE_MISO_ACK){
   if (tmpcmdq->prev==NULL) return LIBSWD_ERROR_ACKMISSING;
-  tmpcmdq=tmpcmdq->prev; 
+  tmpcmdq=tmpcmdq->prev;
  }
  /* If command was found and executed, read received ACK code, or error code. */
  if (tmpcmdq->cmdtype==LIBSWD_CMDTYPE_MISO_ACK && tmpcmdq->done){
   /* Verify data address found on the queue, with pointer selected before run.*/
   if (&tmpcmdq->ack!=*ack) return LIBSWD_ERROR_ACKMISMATCH;
-  return qcmdcnt+tcmdcnt; 
+  return qcmdcnt+tcmdcnt;
  } else return LIBSWD_ERROR_ACKNOTDONE;
 }
 
@@ -253,7 +253,7 @@ int libswd_bus_write_data_p
  qcmdcnt=+res;
 
  if (operation==LIBSWD_OPERATION_ENQUEUE){
-  return qcmdcnt;       
+  return qcmdcnt;
  } else if (operation==LIBSWD_OPERATION_EXECUTE){
   res=libswd_cmdq_flush(libswdctx, &libswdctx->cmdq, operation);
   if (res<0) return res;
@@ -286,7 +286,7 @@ int libswd_bus_write_data_ap(libswd_ctx_t *libswdctx, libswd_operation_t operati
  qcmdcnt=+res;
 
  if (operation==LIBSWD_OPERATION_ENQUEUE){
-  return qcmdcnt;       
+  return qcmdcnt;
  } else if (operation==LIBSWD_OPERATION_EXECUTE) {
   res=libswd_cmdq_flush(libswdctx, &libswdctx->cmdq, operation);
   if (res<0) return res;
@@ -306,7 +306,7 @@ int libswd_bus_read_data_p(libswd_ctx_t *libswdctx, libswd_operation_t operation
  if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
- 
+
  int res, qcmdcnt=0, tcmdcnt=0;
  libswd_cmd_t *tmpcmdq;
 
@@ -319,7 +319,7 @@ int libswd_bus_read_data_p(libswd_ctx_t *libswdctx, libswd_operation_t operation
  qcmdcnt=+res;
 
  if (operation==LIBSWD_OPERATION_ENQUEUE){
-  return qcmdcnt;        
+  return qcmdcnt;
  } else if (operation==LIBSWD_OPERATION_EXECUTE){
   res=libswd_cmdq_flush(libswdctx, &libswdctx->cmdq, operation);
   if (res<2) return res;
@@ -334,7 +334,7 @@ int libswd_bus_read_data_p(libswd_ctx_t *libswdctx, libswd_operation_t operation
  /* Search backward for our MISO_DATA command on the queue. */
  while (tmpcmdq->cmdtype!=LIBSWD_CMDTYPE_MISO_DATA){
   if (tmpcmdq->prev==NULL) return LIBSWD_ERROR_NODATACMD;
-  tmpcmdq=tmpcmdq->prev; 
+  tmpcmdq=tmpcmdq->prev;
  }
  /* There should be parity bit (command) just after data (command). */
  if (tmpcmdq->next->cmdtype!=LIBSWD_CMDTYPE_MISO_PARITY)
@@ -344,7 +344,7 @@ int libswd_bus_read_data_p(libswd_ctx_t *libswdctx, libswd_operation_t operation
   if (tmpcmdq->next->cmdtype==LIBSWD_CMDTYPE_MISO_PARITY && tmpcmdq->next->done){
    if (*data!=&tmpcmdq->misodata) return LIBSWD_ERROR_DATAPTR;
    if (*parity!=&tmpcmdq->next->parity) return LIBSWD_ERROR_PARITYPTR;
-   return qcmdcnt+tcmdcnt; 
+   return qcmdcnt+tcmdcnt;
   } else return LIBSWD_ERROR_NOTDONE;
  }
  return LIBSWD_OK;
@@ -355,7 +355,7 @@ int libswd_bus_read_data_p(libswd_ctx_t *libswdctx, libswd_operation_t operation
  * \param operation can be LIBSWD_OPERATION_ENQUEUE or LIBSWD_OPERATION_EXECUTE.
  * \param *ctlmsg byte/char array that contains control payload.
  * \param len number of bytes in the *ctlmsg to send.
- * \return number of bytes sent or LIBSWD_ERROR_CODE on failure. 
+ * \return number of bytes sent or LIBSWD_ERROR_CODE on failure.
  */
 int libswd_bus_write_control(libswd_ctx_t *libswdctx, libswd_operation_t operation, char *ctlmsg, int len){
  if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
@@ -376,7 +376,7 @@ int libswd_bus_write_control(libswd_ctx_t *libswdctx, libswd_operation_t operati
  qcmdcnt=+res;
 
  if (operation==LIBSWD_OPERATION_ENQUEUE){
-  return qcmdcnt;        
+  return qcmdcnt;
  } else if (operation==LIBSWD_OPERATION_EXECUTE){
   res=libswd_cmdq_flush(libswdctx, &libswdctx->cmdq, operation);
   if (res<0) return res;

--- a/src/libswd_cli.c
+++ b/src/libswd_cli.c
@@ -61,7 +61,7 @@ int libswd_cli_print_usage(libswd_ctx_t *libswdctx)
 }
 
 /** Command Line Interface parse and execution engine.
- * Multiple commands invocation is possible, split by '\n' or ';' characters. 
+ * Multiple commands invocation is possible, split by '\n' or ';' characters.
  * \param *libswdctx libswd context
  * \param *cmd command string pointer
  * \return LIBSWD_ERROR_OK on success or negative value error code otherwise.
@@ -85,13 +85,13 @@ int libswd_cli(libswd_ctx_t *libswdctx, char *command)
    // Strip heading and trailing spaces.
    if (cmd && thiscommand) if (!cmd[0] && thiscommand[0]) continue;
    if (cmd && thiscommand) if (!cmd[0] && !thiscommand[0]) break;
- 
+
    // Check for HELP invocation.
    if ( strncmp(cmd,"?",1)==0 || strncmp(cmd,"help",4)==0 || strncmp(cmd,"h",1)==0 )
    {
-    return libswd_cli_print_usage(libswdctx); 
+    return libswd_cli_print_usage(libswdctx);
    }
- 
+
    // Check for LOGLEVEL invocation.
    else if ( strncmp(cmd,"l",1)==0 || strncmp(cmd,"loglevel",8)==0 )
    {
@@ -133,7 +133,7 @@ int libswd_cli(libswd_ctx_t *libswdctx, char *command)
                libswd_log_level_string(libswdctx->config.loglevel));
     continue;
    }
- 
+
    // Initialize Target subsystems.
    // This will bring components into known state and remove any pending errors.
    else if ( strncmp(cmd,"i",1)==0 || strncmp(cmd,"init",4)==0 )
@@ -147,7 +147,7 @@ int libswd_cli(libswd_ctx_t *libswdctx, char *command)
      {
       libswd_log(libswdctx, LIBSWD_LOGLEVEL_ERROR,
                  "LIBSWD_E: libswd_cli(): Cannot Initialize DAP! (%s)\n",
-                 libswd_error_string(retval) ); 
+                 libswd_error_string(retval) );
        libswd_log(libswdctx, LIBSWD_LOGLEVEL_NORMAL,
                  "LIBSWD_N: libswd_cli(): DAP INIT ERROR!\n" );
      } else libswd_log(libswdctx, LIBSWD_LOGLEVEL_NORMAL,
@@ -251,7 +251,7 @@ int libswd_cli(libswd_ctx_t *libswdctx, char *command)
       {
        cmd=strsep(&thiscommand," ");
        errno=LIBSWD_OK;
-       count=strtol(cmd, &endptr, 0); 
+       count=strtol(cmd, &endptr, 0);
        if (errno!=LIBSWD_OK || count<=0) goto libswd_cli_syntaxerror;
       } else count=4;
       // Make sure count is 32-bit boundary.
@@ -275,12 +275,12 @@ int libswd_cli(libswd_ctx_t *libswdctx, char *command)
        if (!libswdctx->membuf.data)
        {
         libswdctx->membuf.size=0;
-        libswd_log(libswdctx, LIBSWD_ERROR_OUTOFMEM, 
+        libswd_log(libswdctx, LIBSWD_ERROR_OUTOFMEM,
                    "LIBSWD_E: libswd_cli(): Cannot (re)allocate memory buffer!\n");
         retval=LIBSWD_ERROR_OUTOFMEM;
         goto libswd_cli_error;
        } else memset((void*)libswdctx->membuf.data, 0xFF, libswdctx->membuf.size);
-      } else libswdctx->membuf.size=count*sizeof(char); 
+      } else libswdctx->membuf.size=count*sizeof(char);
       // Perform MEM-AP read.
       retval=libswd_memap_read_char_32(libswdctx, LIBSWD_OPERATION_EXECUTE,
                                        addrstart, count,
@@ -300,13 +300,13 @@ int libswd_cli(libswd_ctx_t *libswdctx, char *command)
        }
        retval=fwrite(libswdctx->membuf.data, sizeof(char), count, fp);
        if (!retval)
-        libswd_log(libswdctx, LIBSWD_LOGLEVEL_WARNING, 
+        libswd_log(libswdctx, LIBSWD_LOGLEVEL_WARNING,
                    "LIBSWD_W: libswd_cli(): Cannot write to data file '%s' (%s)!\n",
                    filename, strerror(errno) );
        retval=fclose(fp);
        if (retval)
        {
-        libswd_log(libswdctx, LIBSWD_LOGLEVEL_WARNING, 
+        libswd_log(libswdctx, LIBSWD_LOGLEVEL_WARNING,
                    "LIBSWD_W: libswd_cli(): Cannot close data file '%s' (%s)!\n",
                    filename, strerror(errno) );
        }
@@ -330,7 +330,7 @@ int libswd_cli(libswd_ctx_t *libswdctx, char *command)
     }
     continue;
    }
- 
+
    // Check for WRITE invocation.
    else if ( strncmp(cmd,"w",1)==0 || strncmp(cmd,"write",5)==0 )
    {
@@ -489,7 +489,7 @@ int libswd_cli(libswd_ctx_t *libswdctx, char *command)
        retval=fread(libswdctx->membuf.data, sizeof(char), libswdctx->membuf.size, fp);
        if (!retval)
        {
-        libswd_log(libswdctx, LIBSWD_LOGLEVEL_WARNING, 
+        libswd_log(libswdctx, LIBSWD_LOGLEVEL_WARNING,
                    "LIBSWD_E: libswd_cli(): Cannot load data from '%s' file (%s), aborting!\n",
                    filename, strerror(errno) );
         res=LIBSWD_ERROR_FILE;
@@ -499,7 +499,7 @@ libswd_cli_write_memap_file_load_error:
        retval=fclose(fp);
        if (retval)
        {
-        libswd_log(libswdctx, LIBSWD_LOGLEVEL_WARNING, 
+        libswd_log(libswdctx, LIBSWD_LOGLEVEL_WARNING,
                    "LIBSWD_E: libswd_cli(): Cannot close data file '%s' (%s), aborting!\n",
                    filename, strerror(errno) );
         return LIBSWD_ERROR_FILE;
@@ -541,11 +541,11 @@ libswd_cli_write_memap_file_load_ok:
                "LIBSWD_E: libswd_cli(): %s.\n",
                libswd_error_string(LIBSWD_ERROR_CLISYNTAX) );
                libswd_cli_print_usage(libswdctx);
-    return LIBSWD_ERROR_CLISYNTAX; 
-   } 
+    return LIBSWD_ERROR_CLISYNTAX;
+   }
   }
  }
- 
+
   return LIBSWD_OK;
 
 libswd_cli_syntaxerror:

--- a/src/libswd_cmd.c
+++ b/src/libswd_cmd.c
@@ -80,12 +80,12 @@ int libswd_cmd_enqueue_mosi_request(libswd_ctx_t *libswdctx, char *request){
  res=libswd_cmd_enqueue(libswdctx, cmd);
  if (res<1) free(cmd);
  return res;
-} 
+}
 
 /** Append command queue with Turnaround activating MOSI mode.
  * \param *libswdctx swd context pointer.
  * \return return number elements appended (1), or LIBSWD_ERROR_CODE on failure.
- */ 
+ */
 int libswd_cmd_enqueue_mosi_trn(libswd_ctx_t *libswdctx){
  if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  int res;
@@ -198,7 +198,7 @@ int i;
  * \param *libswdctx swd context pointer.
  * \param *parity parity value pointer.
  * \return number of elements appended (1), or LIBSWD_ERROR_CODE on failure.
- */ 
+ */
 int libswd_cmd_enqueue_mosi_parity(libswd_ctx_t *libswdctx, char *parity){
  if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (*parity!=0 && *parity!=1) return LIBSWD_ERROR_PARAM;
@@ -430,7 +430,7 @@ int libswd_cmd_enqueue_mosi_control(libswd_ctx_t *libswdctx, char *ctlmsg, int l
   cmd->control=ctlmsg[elm];
   cmd->cmdtype=LIBSWD_CMDTYPE_MOSI_CONTROL;
   cmd->bits=sizeof(ctlmsg[elm])*LIBSWD_DATA_BYTESIZE;
-  res=libswd_cmd_enqueue(libswdctx, cmd); 
+  res=libswd_cmd_enqueue(libswdctx, cmd);
   if (res<1) break;
   cmdcnt=+res;
  }

--- a/src/libswd_cmdq.c
+++ b/src/libswd_cmdq.c
@@ -97,7 +97,7 @@ libswd_cmd_t* libswd_cmdq_find_exectail(libswd_cmd_t *cmdq){
 /** Append element pointed by *cmd at the end of the quque pointed by *cmdq.
  * After this operation queue will be pointed by appended element (ie. last
  * element added becomes actual quque pointer to show what was added recently).
- * \param *cmdq pointer to any element on command queue 
+ * \param *cmdq pointer to any element on command queue
  * \param *cmd pointer to the command to be appended
  * \return number of appended elements (one), LIBSWD_ERROR_CODE on failure
  */
@@ -163,7 +163,7 @@ int libswd_cmdq_free_tail(libswd_cmd_t *cmdq){
  libswd_cmd_t *cmdqend;
  if (cmdq->next==NULL) return 0;
  cmdqend=libswd_cmdq_find_tail(cmdq->next);
- if (cmdqend==NULL) return LIBSWD_ERROR_QUEUE; 
+ if (cmdqend==NULL) return LIBSWD_ERROR_QUEUE;
  while(cmdqend!=cmdq){
   cmdqend=cmdqend->prev;
   free(cmdqend->next);
@@ -238,11 +238,11 @@ int libswd_cmdq_flush(libswd_ctx_t *libswdctx, libswd_cmd_t **cmdq, libswd_opera
     continue;
    } else break;
   }
-  res=libswd_drv_transmit(libswdctx, cmd); 
+  res=libswd_drv_transmit(libswdctx, cmd);
   if (res<0) return res;
   cmdcnt=+res;
   if (cmd==lastcmd) break;
- } 
+ }
  *cmdq=cmd;
  return cmdcnt;
 }

--- a/src/libswd_core.c
+++ b/src/libswd_core.c
@@ -84,7 +84,7 @@ int libswd_deinit_ctx(libswd_ctx_t *libswdctx){
 /** De-initialize command queue and free its memory on selected swd context.
  * \param *libswdctx swd context pointer.
  * \return number of commands freed, or LIBSWD_ERROR_CODE on failure.
- */ 
+ */
 int libswd_deinit_cmdq(libswd_ctx_t *libswdctx){
  if (libswdctx==NULL) return LIBSWD_ERROR_NULLPOINTER;
  int res;
@@ -96,7 +96,7 @@ int libswd_deinit_cmdq(libswd_ctx_t *libswdctx){
 /** De-initialize selected swd context and its command queue.
  * \param *libswdctx swd context pointer.
  * \return number of elements freed, or LIBSWD_ERROR_CODE on failure.
- */ 
+ */
 int libswd_deinit(libswd_ctx_t *libswdctx){
  int res, cmdcnt=0;
  if (libswdctx->membuf.data) free(libswdctx->membuf.data);

--- a/src/libswd_dap.c
+++ b/src/libswd_dap.c
@@ -55,7 +55,7 @@
  * \param *libswdctx swd context pointer.
  * \param operation type (LIBSWD_OPERATION_ENQUEUE or LIBSWD_OPERATION_EXECUTE).
  * \return Target's IDCODE, or LIBSWD_ERROR_CODE on failure.
- */ 
+ */
 int libswd_dap_init(libswd_ctx_t *libswdctx, libswd_operation_t operation, int **idcode){
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG,
             "LIBSWD_D: libswd_dap_init(*libswdctx=@%p, operation=%s, **idcode=@%p) entring function...\n",
@@ -78,7 +78,7 @@ int libswd_dap_init(libswd_ctx_t *libswdctx, libswd_operation_t operation, int *
 }
 
 
-/** Setup the DAP. Terget CTRL/STAT 
+/** Setup the DAP. Terget CTRL/STAT
  * This function will:
  * 1. Clear errors by writing to DP ABORT, 2. Power up the System and Debug
  * by writing to DP CTRL/STAT, 3. Set the desired DP CTRL/STAT value.
@@ -105,7 +105,7 @@ int libswd_dap_setup(libswd_ctx_t *libswdctx, libswd_operation_t operation, int 
   *ctrlstat|=LIBSWD_DP_CTRLSTAT_CDBGPWRUPREQ|LIBSWD_DP_CTRLSTAT_CSYSPWRUPREQ;
   // Write to CTRL/STAT register.
   res=libswd_dp_write(libswdctx, operation, LIBSWD_DP_CTRLSTAT_ADDR, ctrlstat);
-  if (res<0) goto libswd_dap_setup_error; 
+  if (res<0) goto libswd_dap_setup_error;
   // Wait for System and Debug Unit powerup.
   for (i=LIBSWD_RETRY_COUNT_DEFAULT;i;i--)
   {
@@ -124,7 +124,7 @@ int libswd_dap_setup(libswd_ctx_t *libswdctx, libswd_operation_t operation, int 
    libswd_log(libswdctx, LIBSWD_LOGLEVEL_WARNING,
               "LIBSWD_W: libswd_dap_setup(): CDBGPWRUPACK/CSYSPWRUPACK not set in DP CTRL/STAT!\n",
               libswdctx->log.dp.ctrlstat );
-   res=LIBSWD_ERROR_MAXRETRY; 
+   res=LIBSWD_ERROR_MAXRETRY;
    goto libswd_dap_setup_error;
   }
  }
@@ -153,7 +153,7 @@ int libswd_dap_reset(libswd_ctx_t *libswdctx, libswd_operation_t operation){
 
  if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
-  return LIBSWD_ERROR_BADOPCODE;  
+  return LIBSWD_ERROR_BADOPCODE;
 
  int res, qcmdcnt=0, tcmdcnt=0;
  libswdctx->log.memap.initialized=0;
@@ -200,7 +200,7 @@ int libswd_dap_select(libswd_ctx_t *libswdctx, libswd_operation_t operation){
 
  if (operation==LIBSWD_OPERATION_ENQUEUE)
  {
-  return qcmdcnt;       
+  return qcmdcnt;
  }
  else if (operation==LIBSWD_OPERATION_EXECUTE)
  {
@@ -225,7 +225,7 @@ int libswd_dap_errors_handle(libswd_ctx_t *libswdctx, libswd_operation_t operati
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG,
             "LIBSWD_D: Executing libswd_dap_errors_handle(*libswdctx=@%p, operation=%s, *abort=0x%X@%p, *ctrlstat=0x%X@%p)\n",
             (void*)libswdctx, libswd_operation_string(operation),
-            (void*)abort, abort?*abort:0, ctrlstat?*ctrlstat:0, 
+            (void*)abort, abort?*abort:0, ctrlstat?*ctrlstat:0,
             (void*)ctrlstat );
 
  if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
@@ -234,7 +234,7 @@ int libswd_dap_errors_handle(libswd_ctx_t *libswdctx, libswd_operation_t operati
  int res, abortreg;
  char APnDP=0, R=1, W=0, ctrlstat_addr=LIBSWD_DP_CTRLSTAT_ADDR, abort_addr=LIBSWD_DP_ABORT_ADDR, *ack, *parity, cparity;
  if (abort) {
-  *abort=*abort&(LIBSWD_DP_ABORT_STKCMPCLR|LIBSWD_DP_ABORT_STKERRCLR|LIBSWD_DP_ABORT_WDERRCLR|LIBSWD_DP_ABORT_ORUNERRCLR); 
+  *abort=*abort&(LIBSWD_DP_ABORT_STKCMPCLR|LIBSWD_DP_ABORT_STKERRCLR|LIBSWD_DP_ABORT_WDERRCLR|LIBSWD_DP_ABORT_ORUNERRCLR);
   res=libswd_bus_write_request(libswdctx, operation, &APnDP, &W, &abort_addr);
   if (res<0) return res;
   res=libswd_bus_read_ack(libswdctx, operation, &ack);
@@ -243,7 +243,7 @@ int libswd_dap_errors_handle(libswd_ctx_t *libswdctx, libswd_operation_t operati
   if (res<0) return res;
  }
  if (ctrlstat){
-  res=libswd_bus_write_request(libswdctx, operation, &APnDP, &R, &ctrlstat_addr); 
+  res=libswd_bus_write_request(libswdctx, operation, &APnDP, &R, &ctrlstat_addr);
   if (res<0) return res;
   res=libswd_bus_read_ack(libswdctx, operation, &ack);
   if (res<0) return res;
@@ -266,7 +266,7 @@ int libswd_dap_errors_handle(libswd_ctx_t *libswdctx, libswd_operation_t operati
 int libswd_dp_read_idcode(libswd_ctx_t *libswdctx, libswd_operation_t operation, int **idcode){
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG, "LIBSWD_D: libswd_dp_read_idcode(*libswdctx=%p, operation=%s): entering function...\n", (void*)libswdctx, libswd_operation_string(operation));
 
- if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT; 
+ if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
          return LIBSWD_ERROR_BADOPCODE;
 
@@ -300,7 +300,7 @@ int libswd_dp_read_idcode(libswd_ctx_t *libswdctx, libswd_operation_t operation,
   libswdctx->log.dp.idcode=**idcode;
   libswdctx->log.dp.parity=*parity;
   libswdctx->log.dp.ack   =*ack;
-  res=libswd_bin32_parity_even(*idcode, &cparity); 
+  res=libswd_bin32_parity_even(*idcode, &cparity);
   if (res<0) return res;
   if (cparity!=*parity) return LIBSWD_ERROR_PARITY;
   libswd_log(libswdctx, LIBSWD_LOGLEVEL_INFO, "LIBSWD_I: libswd_dp_read_idcode(libswdctx=@%p, operation=%s, **idcode=0x%X/%s).\n", (void*)libswdctx, libswd_operation_string(operation), **idcode, libswd_bin32_string(*idcode));
@@ -313,7 +313,7 @@ int libswd_dp_read_idcode(libswd_ctx_t *libswdctx, libswd_operation_t operation,
  * \param *libswdctx swd context pointer.
  * \param operation type (LIBSWD_OPERATION_ENQUEUE or LIBSWD_OPERATION_EXECUTE).
  * \return Target's IDCODE, or LIBSWD_ERROR_CODE on failure.
- */ 
+ */
 int libswd_dap_detect(libswd_ctx_t *libswdctx, libswd_operation_t operation, int **idcode){
  int res;
  res=libswd_dap_select(libswdctx, operation);
@@ -336,8 +336,8 @@ int libswd_dap_detect(libswd_ctx_t *libswdctx, libswd_operation_t operation, int
  */
 int libswd_dp_read(libswd_ctx_t *libswdctx, libswd_operation_t operation, char addr, int **data){
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG, "LIBSWD_D: libswd_dp_read(libswdctx=@%p, operation=%s, addr=0x%X, **data=%p) entering function...\n", (void*)libswdctx, libswd_operation_string(operation), addr, (void**)&data);
- 
- if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT; 
+
+ if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (data==NULL) return LIBSWD_ERROR_NULLPOINTER;
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
@@ -368,7 +368,7 @@ int libswd_dp_read(libswd_ctx_t *libswdctx, libswd_operation_t operation, char a
   if (res>=0) {
    res=libswd_bus_read_data_p(libswdctx, operation, data, &parity);
    if (res<0) return res;
-   res=libswd_bin32_parity_even(*data, &cparity); 
+   res=libswd_bin32_parity_even(*data, &cparity);
    if (res<0) return res;
    if (cparity!=*parity) return LIBSWD_ERROR_PARITY;
    cmdcnt=+res;
@@ -380,7 +380,7 @@ int libswd_dp_read(libswd_ctx_t *libswdctx, libswd_operation_t operation, char a
     res=libswd_dap_errors_handle(libswdctx, LIBSWD_OPERATION_EXECUTE, &abort, &ctrlstat);
     if (res<0) continue;
     res=libswd_bus_write_request_raw(libswdctx, LIBSWD_OPERATION_ENQUEUE, &request);
-    if (res<0) continue; 
+    if (res<0) continue;
     res=libswd_bus_read_ack(libswdctx, LIBSWD_OPERATION_EXECUTE, &ack);
     if (res<0) continue;
     res=libswd_bus_read_data_p(libswdctx, LIBSWD_OPERATION_EXECUTE, data, &parity);
@@ -409,7 +409,7 @@ int libswd_dp_read(libswd_ctx_t *libswdctx, libswd_operation_t operation, char a
   }
   return cmdcnt;
  } else return LIBSWD_ERROR_BADOPCODE;
-} 
+}
 
 /** Macro function: Generic write of the DP register.
  * When operation is LIBSWD_OPERATION_EXECUTE it also caches register values.
@@ -422,7 +422,7 @@ int libswd_dp_read(libswd_ctx_t *libswdctx, libswd_operation_t operation, char a
 int libswd_dp_write(libswd_ctx_t *libswdctx, libswd_operation_t operation, char addr, int *data){
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG, "LIBSWD_D: libswd_dp_write(*libswdctx=%p, operation=%s, addr=0x%X, *data=%p) entering function...\n", (void*)libswdctx, libswd_operation_string(operation), addr, (void*)data);
 
- if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT; 
+ if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (data==NULL) return LIBSWD_ERROR_NULLPOINTER;
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
@@ -434,7 +434,7 @@ int libswd_dp_write(libswd_ctx_t *libswdctx, libswd_operation_t operation, char 
  RnW=0;
 
  res=libswd_bitgen8_request(libswdctx, &APnDP, &RnW, &addr, &request);
- if (res<0) return res; 
+ if (res<0) return res;
  res=libswd_bus_write_request_raw(libswdctx, LIBSWD_OPERATION_ENQUEUE, &request);
  if (res<1) return res;
  cmdcnt=+res;
@@ -459,10 +459,10 @@ int libswd_dp_write(libswd_ctx_t *libswdctx, libswd_operation_t operation, char 
    int retry, ctrlstat, abort;
    for (retry=LIBSWD_RETRY_COUNT_DEFAULT; retry>0; retry--){
     abort=0xFFFFFFFF;
-    res=libswd_dap_errors_handle(libswdctx, LIBSWD_OPERATION_EXECUTE, &abort, &ctrlstat); 
+    res=libswd_dap_errors_handle(libswdctx, LIBSWD_OPERATION_EXECUTE, &abort, &ctrlstat);
     if (res<0) continue;
     res=libswd_bus_write_request_raw(libswdctx, LIBSWD_OPERATION_ENQUEUE, &request);
-    if (res<0) continue; 
+    if (res<0) continue;
     res=libswd_bus_read_ack(libswdctx, LIBSWD_OPERATION_EXECUTE, &ack);
     if (res<0) continue;
     res=libswd_bus_write_data_ap(libswdctx, LIBSWD_OPERATION_EXECUTE, data);
@@ -489,7 +489,7 @@ int libswd_dp_write(libswd_ctx_t *libswdctx, libswd_operation_t operation, char 
   }
   return cmdcnt;
  } else return LIBSWD_ERROR_BADOPCODE;
-} 
+}
 
 /** Macro function: Selects APBANK based on provided address value.
  * Bank number is calculated from [7..4] bits of the address.
@@ -509,7 +509,7 @@ int libswd_ap_bank_select(libswd_ctx_t *libswdctx, libswd_operation_t operation,
  int retval;
  int new_select=libswdctx->log.dp.select;
  new_select&=~LIBSWD_DP_SELECT_APBANKSEL;
- new_select|=addr&LIBSWD_DP_SELECT_APBANKSEL; 
+ new_select|=addr&LIBSWD_DP_SELECT_APBANKSEL;
  retval=libswd_dp_write(libswdctx, operation, LIBSWD_DP_SELECT_ADDR, &new_select);
  if (retval<0){
   libswd_log(libswdctx, LIBSWD_LOGLEVEL_WARNING, "libswd_ap_bank_select(%p, %0x02X): cannot update DP SELECT register (%s)\n", (void*)libswdctx, addr, libswd_error_string(retval));
@@ -557,7 +557,7 @@ int libswd_ap_select(libswd_ctx_t *libswdctx, libswd_operation_t operation, int 
 int libswd_ap_read(libswd_ctx_t *libswdctx, libswd_operation_t operation, char addr, int **data){
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG, "LIBSWD_D: libswd_ap_read(*libswdctx=%p, command=%s, addr=0x%X, *data=%p) entering function...\n", (void*)libswdctx, libswd_operation_string(operation), (unsigned char)addr, (void**)data);
 
- if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT; 
+ if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (data==NULL) return LIBSWD_ERROR_NULLPOINTER;
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
@@ -598,7 +598,7 @@ int libswd_ap_read(libswd_ctx_t *libswdctx, libswd_operation_t operation, char a
     res=libswd_dap_errors_handle(libswdctx, LIBSWD_OPERATION_EXECUTE, &abort, NULL);
     if (res<0) continue;
     res=libswd_bus_write_request_raw(libswdctx, LIBSWD_OPERATION_ENQUEUE, &request);
-    if (res<0) continue; 
+    if (res<0) continue;
     res=libswd_bus_read_ack(libswdctx, LIBSWD_OPERATION_EXECUTE, &ack);
     if (res<0) continue;
     res=libswd_bus_read_data_p(libswdctx, LIBSWD_OPERATION_EXECUTE, data, &parity);
@@ -619,7 +619,7 @@ int libswd_ap_read(libswd_ctx_t *libswdctx, libswd_operation_t operation, char a
   libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG, "LIBSWD_D: libswd_ap_read(libswdctx=@%p, command=%s, addr=0x%X, **data=0x%X/%s) execution OK.\n", (void*)libswdctx, libswd_operation_string(operation), addr, **data, libswd_bin32_string(*data));
   return cmdcnt;
  } else return LIBSWD_ERROR_BADOPCODE;
-} 
+}
 
 /** Macro function: Generic write of the AP register.
  * Address field should contain AP BANK on bits [4..7].
@@ -631,8 +631,8 @@ int libswd_ap_read(libswd_ctx_t *libswdctx, libswd_operation_t operation, char a
  */
 int libswd_ap_write(libswd_ctx_t *libswdctx, libswd_operation_t operation, char addr, int *data){
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG, "LIBSWD_D: libswd_ap_write(libswdctx=@%p, operation=%s, addr=0x%X, *data=0x%X).\n", (void*)libswdctx, libswd_operation_string(operation), addr, (void**)data);
- 
- if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT; 
+
+ if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
@@ -675,7 +675,7 @@ int libswd_ap_write(libswd_ctx_t *libswdctx, libswd_operation_t operation, char 
     res=libswd_dap_errors_handle(libswdctx, LIBSWD_OPERATION_EXECUTE, &abort, NULL);
     if (res<0) continue;
     res=libswd_bus_write_request_raw(libswdctx, LIBSWD_OPERATION_ENQUEUE, &request);
-    if (res<0) continue; 
+    if (res<0) continue;
     res=libswd_bus_read_ack(libswdctx, LIBSWD_OPERATION_EXECUTE, &ack);
     if (res<0) continue;
     res=libswd_bus_write_data_ap(libswdctx, LIBSWD_OPERATION_EXECUTE, data);
@@ -687,14 +687,14 @@ int libswd_ap_write(libswd_ctx_t *libswdctx, libswd_operation_t operation, char 
   if (res<0) {
    libswd_log(libswdctx, LIBSWD_LOGLEVEL_ERROR, "LIBSWD_E: libswd_ap_write(libswdctx=@%p, operation=%s, addr=0x%X, *data=0x%X/%s) failed: %s.\n", (void*)libswdctx, libswd_operation_string(operation), addr, *data, libswd_bin32_string(data), libswd_error_string(res));
    abort=0xFFFFFFFE;
-   res=libswd_dap_errors_handle(libswdctx, LIBSWD_OPERATION_EXECUTE, &abort, &ctrlstat); 
+   res=libswd_dap_errors_handle(libswdctx, LIBSWD_OPERATION_EXECUTE, &abort, &ctrlstat);
    return res;
   }
   libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG, "LIBSWD_D: libswd_ap_write(libswdctx=@%p, operation=%s, addr=0x%X, *data=0x%X/%s) execution OK.\n", (void*)libswdctx, libswd_operation_string(operation), addr, *data, libswd_bin32_string(data));
   return cmdcnt;
  } else return LIBSWD_ERROR_BADOPCODE;
  return LIBSWD_OK;
-} 
+}
 
 
 

--- a/src/libswd_dap.c
+++ b/src/libswd_dap.c
@@ -231,7 +231,7 @@ int libswd_dap_errors_handle(libswd_ctx_t *libswdctx, libswd_operation_t operati
  if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (operation!=LIBSWD_OPERATION_EXECUTE && operation!=LIBSWD_OPERATION_ENQUEUE) return LIBSWD_ERROR_BADOPCODE;
 
- int res, abortreg;
+ int res;
  char APnDP=0, R=1, W=0, ctrlstat_addr=LIBSWD_DP_CTRLSTAT_ADDR, abort_addr=LIBSWD_DP_ABORT_ADDR, *ack, *parity, cparity;
  if (abort) {
   *abort=*abort&(LIBSWD_DP_ABORT_STKCMPCLR|LIBSWD_DP_ABORT_STKERRCLR|LIBSWD_DP_ABORT_WDERRCLR|LIBSWD_DP_ABORT_ORUNERRCLR);
@@ -428,7 +428,7 @@ int libswd_dp_write(libswd_ctx_t *libswdctx, libswd_operation_t operation, char 
   return LIBSWD_ERROR_BADOPCODE;
 
  int res, cmdcnt=0;
- char APnDP, RnW, cparity, *ack, *parity, request;
+ char APnDP, RnW, *ack, request;
 
  APnDP=0;
  RnW=0;
@@ -563,7 +563,7 @@ int libswd_ap_read(libswd_ctx_t *libswdctx, libswd_operation_t operation, char a
   return LIBSWD_ERROR_BADOPCODE;
 
  int res, cmdcnt=0, retry, ctrlstat, abort;
- char APnDP, RnW, cparity, *ack, *parity, request;
+ char APnDP, RnW, *ack, *parity, request;
 
  res=libswd_ap_bank_select(libswdctx, LIBSWD_OPERATION_ENQUEUE, addr);
  if (res<0) return res;
@@ -637,7 +637,7 @@ int libswd_ap_write(libswd_ctx_t *libswdctx, libswd_operation_t operation, char 
   return LIBSWD_ERROR_BADOPCODE;
 
  int res, cmdcnt=0, retry, ctrlstat, abort;
- char APnDP, RnW, cparity, *ack, *parity, request;
+ char APnDP, RnW, *ack, request;
 
  res=libswd_ap_bank_select(libswdctx, LIBSWD_OPERATION_ENQUEUE, addr);
  if (res<0) return res;

--- a/src/libswd_debug.c
+++ b/src/libswd_debug.c
@@ -53,7 +53,6 @@ int libswd_debug_detect(libswd_ctx_t *libswdctx, libswd_operation_t operation)
 
  if (!libswdctx) return LIBSWD_ERROR_NULLCONTEXT;
  int retval=0, i, cpuid;
- libswd_arm_register_t reg;
 
  if (!libswdctx->log.memap.initialized)
  {
@@ -61,16 +60,16 @@ int libswd_debug_detect(libswd_ctx_t *libswdctx, libswd_operation_t operation)
   if (retval<0) return retval;
  }
 
+ retval=libswd_memap_read_int_32(libswdctx, LIBSWD_OPERATION_EXECUTE, LIBSWD_ARM_DEBUG_CPUID_ADDR, 1, &cpuid);
+ if (retval<0) return retval;
+
  for (i=0;i<LIBSWD_NUM_SUPPORTED_CPUIDS;i++)
  {
-  reg=libswd_arm_debug_CPUID[i];
-  retval=libswd_memap_read_int_32(libswdctx, LIBSWD_OPERATION_EXECUTE, reg.address, 1, &cpuid);
-  if (retval<0) return retval;
-  if (cpuid==reg.default_value)
+  if (cpuid==libswd_arm_debug_CPUID[i].default_value)
   {
    libswd_log(libswdctx, LIBSWD_LOGLEVEL_INFO,
               "LIBSWD_I: libswd_debug_detect(): Found supported CPUID=0x%08X (%s).\n",
-              reg.default_value, reg.name );
+              libswd_arm_debug_CPUID[i].default_value, libswd_arm_debug_CPUID[i].name );
    break;
   }
  }

--- a/src/libswd_debug.c
+++ b/src/libswd_debug.c
@@ -52,7 +52,8 @@ int libswd_debug_detect(libswd_ctx_t *libswdctx, libswd_operation_t operation)
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG, "LIBSWD_I: Executing libswd_debug_detect(*libswdctx=%p, operation=%s)\n", (void*)libswdctx, libswd_operation_string(operation));
 
  if (!libswdctx) return LIBSWD_ERROR_NULLCONTEXT;
- int retval=0, i, cpuid;
+ int retval=0, cpuid;
+ unsigned int i;
 
  if (!libswdctx->log.memap.initialized)
  {

--- a/src/libswd_debug.c
+++ b/src/libswd_debug.c
@@ -46,7 +46,7 @@
  * \param *libswdctx swd context pointer.
  * \param operation type (LIBSWD_OPERATION_ENQUEUE or LIBSWD_OPERATION_EXECUTE).
  * \return LIBSWD_OK if Debug Unit is supported, LIBSWD_ERROR_UNSUPPORTED otherwise.
- */ 
+ */
 int libswd_debug_detect(libswd_ctx_t *libswdctx, libswd_operation_t operation)
 {
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG, "LIBSWD_I: Executing libswd_debug_detect(*libswdctx=%p, operation=%s)\n", (void*)libswdctx, libswd_operation_string(operation));
@@ -59,12 +59,12 @@ int libswd_debug_detect(libswd_ctx_t *libswdctx, libswd_operation_t operation)
  {
   retval=libswd_memap_init(libswdctx, operation);
   if (retval<0) return retval;
- } 
+ }
 
  for (reg=libswd_arm_debug_CPUID[i=0];reg.address;reg=libswd_arm_debug_CPUID[i++])
  {
   retval=libswd_memap_read_int_32(libswdctx, LIBSWD_OPERATION_EXECUTE, reg.address, 1, &cpuid);
-  if (retval<0) return retval; 
+  if (retval<0) return retval;
   if (cpuid==reg.default_value)
   {
    libswd_log(libswdctx, LIBSWD_LOGLEVEL_INFO,
@@ -106,7 +106,7 @@ int libswd_debug_halt(libswd_ctx_t *libswdctx, libswd_operation_t operation)
   if (retval<0) return retval;
  }
  // Halt the CPU.
- retval=libswd_memap_read_int_32(libswdctx, operation, LIBSWD_ARM_DEBUG_DHCSR_ADDR, 1, &dbgdhcsr); 
+ retval=libswd_memap_read_int_32(libswdctx, operation, LIBSWD_ARM_DEBUG_DHCSR_ADDR, 1, &dbgdhcsr);
  if (retval<0) return retval;
  for (i=LIBSWD_RETRY_COUNT_DEFAULT;i;i--)
  {
@@ -144,7 +144,7 @@ int libswd_debug_run(libswd_ctx_t *libswdctx, libswd_operation_t operation)
   if (retval<0) return retval;
  }
  // UnHalt the CPU.
- retval=libswd_memap_read_int_32(libswdctx, LIBSWD_OPERATION_EXECUTE, LIBSWD_ARM_DEBUG_DHCSR_ADDR, 1, &dbgdhcsr); 
+ retval=libswd_memap_read_int_32(libswdctx, LIBSWD_OPERATION_EXECUTE, LIBSWD_ARM_DEBUG_DHCSR_ADDR, 1, &dbgdhcsr);
  if (retval<0) return retval;
  for (i=LIBSWD_RETRY_COUNT_DEFAULT;i;i--)
  {

--- a/src/libswd_debug.c
+++ b/src/libswd_debug.c
@@ -61,8 +61,9 @@ int libswd_debug_detect(libswd_ctx_t *libswdctx, libswd_operation_t operation)
   if (retval<0) return retval;
  }
 
- for (reg=libswd_arm_debug_CPUID[i=0];reg.address;reg=libswd_arm_debug_CPUID[i++])
+ for (i=0;i<LIBSWD_NUM_SUPPORTED_CPUIDS;i++)
  {
+  reg=libswd_arm_debug_CPUID[i];
   retval=libswd_memap_read_int_32(libswdctx, LIBSWD_OPERATION_EXECUTE, reg.address, 1, &cpuid);
   if (retval<0) return retval;
   if (cpuid==reg.default_value)
@@ -73,7 +74,7 @@ int libswd_debug_detect(libswd_ctx_t *libswdctx, libswd_operation_t operation)
    break;
   }
  }
- if (!reg.address) return LIBSWD_ERROR_UNSUPPORTED;
+ if (i==LIBSWD_NUM_SUPPORTED_CPUIDS) return LIBSWD_ERROR_UNSUPPORTED;
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG, "LIBSWD_I: libswd_debug_detect(*libswdctx=%p, operation=%s) execution OK...\n", (void*)libswdctx, libswd_operation_string(operation));
  return LIBSWD_OK;
 }

--- a/src/libswd_debug.c
+++ b/src/libswd_debug.c
@@ -98,7 +98,6 @@ int libswd_debug_halt(libswd_ctx_t *libswdctx, libswd_operation_t operation)
  if (operation!=LIBSWD_OPERATION_EXECUTE && operation!=LIBSWD_OPERATION_ENQUEUE) return LIBSWD_ERROR_PARAM;
 
  int retval, i, dbgdhcsr;
- char buf[4];
 
  if (!libswdctx->log.debug.initialized)
  {
@@ -136,7 +135,6 @@ int libswd_debug_run(libswd_ctx_t *libswdctx, libswd_operation_t operation)
  if (operation!=LIBSWD_OPERATION_EXECUTE && operation!=LIBSWD_OPERATION_ENQUEUE) return LIBSWD_ERROR_PARAM;
 
  int retval, i, dbgdhcsr;
- char buf[4];
 
  if (!libswdctx->log.debug.initialized)
  {

--- a/src/libswd_drv.c
+++ b/src/libswd_drv.c
@@ -58,11 +58,11 @@ extern int libswd_drv_miso_trn(libswd_ctx_t *libswdctx, int bits);
  * \param *libswdctx swd context pointer.
  * \param *cmd pointer to the command to be sent.
  * \return number of commands transmitted (1), or LIBSWD_ERROR_CODE on failure.
- */ 
+ */
 int libswd_drv_transmit(libswd_ctx_t *libswdctx, libswd_cmd_t *cmd){
  if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (cmd==NULL) return LIBSWD_ERROR_NULLPOINTER;
-  
+
  int res=LIBSWD_ERROR_BADCMDTYPE, errcode=LIBSWD_ERROR_RESULT;
 
  switch (cmd->cmdtype){
@@ -113,7 +113,7 @@ int libswd_drv_transmit(libswd_ctx_t *libswdctx, libswd_cmd_t *cmd){
 
   case LIBSWD_CMDTYPE_MOSI_DATA:
    // 32 clock cycles.
-   if (cmd->bits!=LIBSWD_DATA_BITLEN) return LIBSWD_ERROR_BADCMDDATA; 
+   if (cmd->bits!=LIBSWD_DATA_BITLEN) return LIBSWD_ERROR_BADCMDDATA;
    res=libswd_drv_mosi_32(libswdctx, cmd, &cmd->mosidata, 32, LIBSWD_DIR_LSBFIRST);
    if (res>=0) libswdctx->log.write.data=cmd->mosidata;
    break;
@@ -155,11 +155,11 @@ int libswd_drv_transmit(libswd_ctx_t *libswdctx, libswd_cmd_t *cmd){
 
   case LIBSWD_CMDTYPE_UNDEFINED:
    res=0;
-   break; 
+   break;
 
   default:
    return LIBSWD_ERROR_BADCMDTYPE;
- } 
+ }
 
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_PAYLOAD,
   "LIBSWD_P: libswd_drv_transmit(libswdctx=@%p, cmd=@%p) bits=%-2d cmdtype=%-12s returns=%-3d payload=0x%08x (%s)\n",

--- a/src/libswd_error.c
+++ b/src/libswd_error.c
@@ -109,7 +109,7 @@ int libswd_error_handle(libswd_ctx_t *libswdctx){
  if (exectail!=libswdctx->cmdq){
   libswd_log(libswdctx, LIBSWD_LOGLEVEL_INFO, "LIBSWD_I: libswd_error_handle(libswdctx=@%p): Correcting libswdctx->cmdq to match last executed element...\n", (void*)libswdctx);
   libswdctx->cmdq=exectail;
- } 
+ }
 
  switch (libswdctx->cmdq->cmdtype){
   case LIBSWD_CMDTYPE_MISO_ACK:
@@ -120,7 +120,7 @@ int libswd_error_handle(libswd_ctx_t *libswdctx){
  }
 
  if (retval<0){
-  libswd_log(libswdctx, LIBSWD_LOGLEVEL_WARNING, "LIBSWD_W: libswd_error_handle(@%p) failed! on cmdq=@%p", (void*)libswdctx, (void*)libswdctx->cmdq); 
+  libswd_log(libswdctx, LIBSWD_LOGLEVEL_WARNING, "LIBSWD_W: libswd_error_handle(@%p) failed! on cmdq=@%p", (void*)libswdctx, (void*)libswdctx->cmdq);
  }
  return retval;
 }
@@ -166,7 +166,7 @@ int libswd_error_handle_ack_wait(libswd_ctx_t *libswdctx){
  //TODO: NOW DECIDE IF AN OPERATION WAS READ OR WRITE AND PERFORM RETRY ACCORDINGLY
  // READ AND WRITE WILL HAVE DIFFERENT RETRY SEQUENCES
 
- char request = libswdctx->cmdq->prev->prev->request; 
+ char request = libswdctx->cmdq->prev->prev->request;
  char *ack, *rparity;
  char parity=0;
 
@@ -188,7 +188,7 @@ int libswd_error_handle_ack_wait(libswd_ctx_t *libswdctx){
  // NOW WE CAN HANDLE MEM-AP READ RETRY:
  // 1. READ STICKY FLAGS FROM CTRL/STAT
  // 2. CLEAR STICKY FLAGS IN ABORT - this will discard AP transaction
- // 3. RETRY MEM-AP DRW READ - now it must be ACK=OK (it will return last mem-ap read result). 
+ // 3. RETRY MEM-AP DRW READ - now it must be ACK=OK (it will return last mem-ap read result).
  // 4. READ DP RDBUFF TO OBTAIN READ DATA
 
  int retrycnt;
@@ -234,9 +234,9 @@ int libswd_error_handle_ack_wait(libswd_ctx_t *libswdctx){
   libswdctx->cmdq->done=1;
   return LIBSWD_OK;
  } else libswd_log(libswdctx, LIBSWD_LOGLEVEL_ERROR, "LIBSWD_E: UNSUPPORTED COMMAND SEQUENCE ON CMDQ (NOT ACK->RDATA->PARITY)\n");
- 
-  
- // At this point we should have the read result from RDBUFF ready for MEM-AP read fix. 
+
+
+ // At this point we should have the read result from RDBUFF ready for MEM-AP read fix.
 
 
 libswd_error_handle_ack_wait_end:

--- a/src/libswd_error.c
+++ b/src/libswd_error.c
@@ -181,7 +181,7 @@ int libswd_error_handle_ack_wait(libswd_ctx_t *libswdctx){
  if (libswdctx->cmdq->errors==NULL) goto libswd_error_handle_ack_wait_end;
  libswdctx->cmdq=libswdctx->cmdq->errors; // From now, this becomes out main cmdq for use with standard functions.
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG, "LIBSWD_D: libswd_error_handle_ack_wait(libswdctx=@%p): Performing data phase after ACK={WAIT,FAULT}...\n", (void*)libswdctx);
- int res, data=0;
+ int data=0;
  retval=libswd_bus_write_data_p(libswdctx, LIBSWD_OPERATION_EXECUTE, &data, &parity);
  if (retval<0) goto libswd_error_handle_ack_wait_end;
 

--- a/src/libswd_error.c
+++ b/src/libswd_error.c
@@ -174,7 +174,7 @@ int libswd_error_handle_ack_wait(libswd_ctx_t *libswdctx){
  libswd_cmd_t *mastercmdq = libswdctx->cmdq;
 
  // Append dummy data phase, fix sticky flags and retry operation.
- int retval, *ctrlstat, *rdata, abort;
+ int retval=0, *ctrlstat, *rdata, abort, retrycnt=50;
 // retval=libswd_cmdq_init(errors);
  libswdctx->cmdq->errors=(libswd_cmd_t*)calloc(1,sizeof(libswd_cmd_t));
  //retval = LIBSWD_ERROR_OUTOFMEM;
@@ -191,7 +191,6 @@ int libswd_error_handle_ack_wait(libswd_ctx_t *libswdctx){
  // 3. RETRY MEM-AP DRW READ - now it must be ACK=OK (it will return last mem-ap read result).
  // 4. READ DP RDBUFF TO OBTAIN READ DATA
 
- int retrycnt;
  for (retrycnt=50/*LIBSWD_RETRY_COUNT_DEFAULT*/; retrycnt>0; retrycnt--){
   retval=libswd_dp_read(libswdctx, LIBSWD_OPERATION_EXECUTE, LIBSWD_DP_CTRLSTAT_ADDR, &ctrlstat);
   if (retval<0) goto libswd_error_handle_ack_wait_end;

--- a/src/libswd_error.c
+++ b/src/libswd_error.c
@@ -87,6 +87,7 @@ char *libswd_error_string(libswd_error_code_t error){
   case LIBSWD_ERROR_FILE:         return "[LIBSWD_ERROR_FILE] file I/O related problem";
   case LIBSWD_ERROR_UNSUPPORTED:  return "[LIBSWD_ERROR_UNSUPPORTED] Target not supported";
   case LIBSWD_ERROR_MEMAPACCSIZE: return "[LIBSWD_ERROR_MEMAPACCSIZE] Invalid MEM-AP access size";
+  case LIBSWD_ERROR_MEMAPALIGN:   return "[LIBSWD_ERROR_MEMAPALIGN] Invalid address alignment for access size";
   default:                        return "undefined error";
  }
  return "undefined error";

--- a/src/libswd_externs.c
+++ b/src/libswd_externs.c
@@ -64,7 +64,7 @@ int libswd_drv_miso_8(libswd_ctx_t *libswdctx, libswd_cmd_t *cmd, char *data, in
  if (nLSBfirst!=0 && nLSBfirst!=1) return LIBSWD_ERROR_PARAM;
 
  // Your code goes here...
- 
+
  return bits;
 }
 
@@ -84,7 +84,7 @@ int libswd_drv_miso_32(libswd_ctx_t *libswdctx, libswd_cmd_t *cmd, int *data, in
  * bits specify how many clock cycles must be used. */
 int libswd_drv_mosi_trn(libswd_ctx_t *libswdctx, int bits){
  if (bits<LIBSWD_TURNROUND_MIN_VAL && bits>LIBSWD_TURNROUND_MAX_VAL)
-  return LIBSWD_ERROR_TURNAROUND; 
+  return LIBSWD_ERROR_TURNAROUND;
 
  // Your code goes here...
 
@@ -93,7 +93,7 @@ int libswd_drv_mosi_trn(libswd_ctx_t *libswdctx, int bits){
 
 int libswd_drv_miso_trn(libswd_ctx_t *libswdctx, int bits){
  if (bits<LIBSWD_TURNROUND_MIN_VAL && bits>LIBSWD_TURNROUND_MAX_VAL)
-  return LIBSWD_ERROR_TURNAROUND; 
+  return LIBSWD_ERROR_TURNAROUND;
 
  // Your code goes here...
 

--- a/src/libswd_log.c
+++ b/src/libswd_log.c
@@ -66,7 +66,7 @@ int libswd_log_internal(libswd_ctx_t *libswdctx, libswd_loglevel_t loglevel, cha
  int res;
  va_list ap;
  va_start(ap, msg);
- res=vprintf(msg, ap);  
+ res=vprintf(msg, ap);
  va_end(ap);
  return res;
 }
@@ -84,7 +84,7 @@ int libswd_log_internal_va(libswd_ctx_t *libswdctx, libswd_loglevel_t loglevel, 
   return LIBSWD_ERROR_LOGLEVEL;
  if (loglevel > libswdctx->config.loglevel) return LIBSWD_OK;
  int res;
- res=vprintf(fmt, ap);  
+ res=vprintf(fmt, ap);
  return res;
 }
 
@@ -141,14 +141,14 @@ const char *libswd_operation_string(libswd_operation_t operation){
   case LIBSWD_OPERATION_TRANSMIT_TAIL: return "LIBSWD_OPERATION_TRANSMIT_TAIL";
   case LIBSWD_OPERATION_TRANSMIT_ALL:  return "LIBSWD_OPERATION_TRANSMIT_ALL";
   case LIBSWD_OPERATION_TRANSMIT_ONE:  return "LIBSWD_OPERATION_TRANSMIT_ONE";
-  case LIBSWD_OPERATION_TRANSMIT_LAST: return "LIBSWD_OPERATION_TRANSMIT_LAST"; 
+  case LIBSWD_OPERATION_TRANSMIT_LAST: return "LIBSWD_OPERATION_TRANSMIT_LAST";
  }
  return "UNKNOWN_LIBSWD_OPERATION";
-} 
+}
 
 /** Helper function that can print name of the request fields.
  * DP SELECT APBANKSEL fields are also taken into account here for APACC.
- * \param libswdctx points to the swd context and its necessary to know 
+ * \param libswdctx points to the swd context and its necessary to know
     DP SELECT register value as it determines CTRL/STAT or WCR access.
  * \param RnW is the read/write bit of the request packet.
  * \param addr is the address of the register.

--- a/src/libswd_memap.c
+++ b/src/libswd_memap.c
@@ -543,19 +543,14 @@ int libswd_memap_read_int_csw(libswd_ctx_t *libswdctx, libswd_operation_t operat
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
- int res=0, accsize=0;
+ int res=0;
 
  // Calculate required access size based on CSW value.
  switch (csw&LIBSWD_MEMAP_CSW_SIZE)
  {
   case LIBSWD_MEMAP_CSW_SIZE_8BIT:
-   accsize=1;
-   break;
   case LIBSWD_MEMAP_CSW_SIZE_16BIT:
-   accsize=2;
-   break;
   case LIBSWD_MEMAP_CSW_SIZE_32BIT:
-   accsize=4;
    break;
   default:
    res=LIBSWD_ERROR_MEMAPACCSIZE;
@@ -949,19 +944,14 @@ int libswd_memap_write_int_csw(libswd_ctx_t *libswdctx, libswd_operation_t opera
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
- int res=0, accsize=0;
+ int res=0;
 
  // Calculate required access size based on CSW value.
  switch (csw&LIBSWD_MEMAP_CSW_SIZE)
  {
   case LIBSWD_MEMAP_CSW_SIZE_8BIT:
-   accsize=1;
-   break;
   case LIBSWD_MEMAP_CSW_SIZE_16BIT:
-   accsize=2;
-   break;
   case LIBSWD_MEMAP_CSW_SIZE_32BIT:
-   accsize=4;
    break;
   default:
    res=LIBSWD_ERROR_MEMAPACCSIZE;

--- a/src/libswd_memap.c
+++ b/src/libswd_memap.c
@@ -43,7 +43,7 @@
  ******************************************************************************/
 
 /** Initialize the MEM-AP.
- * This function will set DbgSwEnable, DeviceEn, 32-bit Size in CSW. 
+ * This function will set DbgSwEnable, DeviceEn, 32-bit Size in CSW.
  * This function will disable Tar Auto Increment.
  * Use libswd_memap_setup() to set specific CSW and TAR values.
  * \param *libswdctx swd context to work on.
@@ -57,7 +57,7 @@ int libswd_memap_init(libswd_ctx_t *libswdctx, libswd_operation_t operation){
  if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
 
  int res=0, *memapidr, *memapbase, *memapcswp, memapcsw;
- int dpabort, dpctrlstat, *dpctrlstatp; 
+ int dpabort, dpctrlstat, *dpctrlstatp;
 
  // Verify if DAP is already initialized, do so in necessary.
  if (!libswdctx->log.dp.initialized)
@@ -68,8 +68,8 @@ int libswd_memap_init(libswd_ctx_t *libswdctx, libswd_operation_t operation){
  }
 
  // Select MEM-AP.
- //res=libswd_ap_select(libswdctx, operation, LIBSWD_MEMAP_APSEL_VAL);  
- //if (res<0) goto libswd_memap_init_error; 
+ //res=libswd_ap_select(libswdctx, operation, LIBSWD_MEMAP_APSEL_VAL);
+ //if (res<0) goto libswd_memap_init_error;
  // TODO: DO WE NEED LIBSWD_AP_SELECT ???
 
  // Check IDentification Register, use cached value if possible.
@@ -128,7 +128,7 @@ libswd_memap_init_error:
  * Use this function to setup CSW and TAR values for given MEM-AP operations.
  * This setup needs to be done before MEM-AP with different access size.
  * Function will try to compare agains chahed values to save bus traffic.
- * This function will set DBGSWENABLE and PROT bits in CSW by default. 
+ * This function will set DBGSWENABLE and PROT bits in CSW by default.
  * \param *libswd LibSWD context to work on.
  * \param operation is the LIBSWD_OPERATION type.
  * \param csw is the CSW register value to be set.
@@ -142,7 +142,7 @@ int libswd_memap_setup(libswd_ctx_t *libswdctx, libswd_operation_t operation, in
 
  if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
 
- int res, *memapcswp, memapcsw, *memaptarp; 
+ int res, *memapcswp, memapcsw, *memaptarp;
 
  // Verify if MEM-AP is already initialized, do so in necessary.
  if (!libswdctx->log.memap.initialized)
@@ -153,7 +153,7 @@ int libswd_memap_setup(libswd_ctx_t *libswdctx, libswd_operation_t operation, in
 
  // Remember to set these bits not to lock-out the Debug...
  memapcsw=csw|LIBSWD_MEMAP_CSW_DBGSWENABLE;
- memapcsw|=LIBSWD_MEMAP_CSW_PROT; // PROT ENABLES DEBUG!! 
+ memapcsw|=LIBSWD_MEMAP_CSW_PROT; // PROT ENABLES DEBUG!!
 
  // Update MEM-AP CSW register if necessary.
  if (memapcsw!=libswdctx->log.memap.csw)
@@ -205,7 +205,7 @@ int libswd_memap_read_char(libswd_ctx_t *libswdctx, libswd_operation_t operation
             (void*)libswdctx, libswd_operation_string(operation),
             addr, count, (void*)data );
 
- if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT; 
+ if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
@@ -350,9 +350,9 @@ int libswd_memap_read_char_csw(libswd_ctx_t *libswdctx, libswd_operation_t opera
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG,
             "LIBSWD_D: Entering libswd_memap_read_char_csw(*libswdctx=%p, operation=%s, addr=0x%08X, count=0x%08X, *data=%p, csw=0x%X)...\n",
             (void*)libswdctx, libswd_operation_string(operation),
-            addr, count, (void**)data, csw); 
+            addr, count, (void**)data, csw);
 
- if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT; 
+ if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
@@ -372,7 +372,7 @@ int libswd_memap_read_char_csw(libswd_ctx_t *libswdctx, libswd_operation_t opera
    break;
   default:
    res=LIBSWD_ERROR_MEMAPACCSIZE;
-   goto libswd_memap_read_char_csw_error; 
+   goto libswd_memap_read_char_csw_error;
  }
  // Verify the count parameter to be access boundary.
  if (count%accsize) count=count-(count%accsize);
@@ -434,9 +434,9 @@ int libswd_memap_read_int(libswd_ctx_t *libswdctx, libswd_operation_t operation,
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG,
             "LIBSWD_D: Entering libswd_memap_read_int(*libswdctx=%p, operation=%s, addr=0x%08X, count=0x%08X, *data=%p)...\n",
             (void*)libswdctx, libswd_operation_string(operation),
-            addr, count, (void**)data); 
+            addr, count, (void**)data);
 
- if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT; 
+ if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
@@ -538,9 +538,9 @@ int libswd_memap_read_int_csw(libswd_ctx_t *libswdctx, libswd_operation_t operat
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG,
             "LIBSWD_D: Entering libswd_memap_read_int_csw(*libswdctx=%p, operation=%s, addr=0x%08X, count=0x%08X, *data=%p, csw=0x%X)...\n",
             (void*)libswdctx, libswd_operation_string(operation),
-            addr, count, (void**)data, csw ); 
+            addr, count, (void**)data, csw );
 
- if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT; 
+ if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
@@ -560,7 +560,7 @@ int libswd_memap_read_int_csw(libswd_ctx_t *libswdctx, libswd_operation_t operat
    break;
   default:
    res=LIBSWD_ERROR_MEMAPACCSIZE;
-   goto libswd_memap_read_int_csw_error; 
+   goto libswd_memap_read_int_csw_error;
  }
 
  // Initialize MEM-AP if necessary.
@@ -577,7 +577,7 @@ int libswd_memap_read_int_csw(libswd_ctx_t *libswdctx, libswd_operation_t operat
  // Perform the read operation.
  res=libswd_memap_read_int(libswdctx, operation, addr, count, data);
  if (res<0) goto libswd_memap_read_int_csw_error;
- 
+
  return LIBSWD_OK;
 
 libswd_memap_read_int_csw_error:
@@ -605,7 +605,7 @@ int libswd_memap_read_int_32(libswd_ctx_t *libswdctx, libswd_operation_t operati
             addr, count, (void**)data);
 
  return libswd_memap_read_int_csw(libswdctx, operation, addr, count, data, LIBSWD_MEMAP_CSW_SIZE_32BIT|LIBSWD_MEMAP_CSW_ADDRINC_SINGLE);
-} 
+}
 
 
 /** Generic write using MEM-AP from char array.
@@ -621,9 +621,9 @@ int libswd_memap_write_char(libswd_ctx_t *libswdctx, libswd_operation_t operatio
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG,
             "LIBSWD_D: Entering libswd_memap_write_char(*libswdctx=%p, operation=%s, addr=0x%08X, count=0x%08X, **data=%p)...\n",
             (void*)libswdctx, libswd_operation_string(operation),
-            addr, count, (void*)data ); 
+            addr, count, (void*)data );
 
- if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT; 
+ if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
@@ -753,7 +753,7 @@ libswd_memap_write_char_error:
  * \param *libswdctx swd context to work on.
  * \param operation can be LIBSWD_OPERATION_ENQUEUE or LIBSWD_OPERATION_EXECUTE.
  * \param addr is the start address of the data to write with MEM-AP.
- * \param count is the number of bytes to write. 
+ * \param count is the number of bytes to write.
  * \param *data is the pointer to data to be written.
  * \param csw is the value of csw register to write prior data write.
  * \return number of elements/words processed or LIBSWD_ERROR code on failure.
@@ -763,7 +763,7 @@ int libswd_memap_write_char_csw(libswd_ctx_t *libswdctx, libswd_operation_t oper
             "LIBSWD_D: Entring libswd_memap_write_char_csw(*libswdctx=%p, operation=%s, addr=0x%08X, count=0x%08X, **data=%p, csw=0x%X)...\n",
             (void*)libswdctx, libswd_operation_string(operation),
             addr, count, (void**)data, csw );
- if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT; 
+ if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
@@ -783,7 +783,7 @@ int libswd_memap_write_char_csw(libswd_ctx_t *libswdctx, libswd_operation_t oper
    break;
   default:
    res=LIBSWD_ERROR_MEMAPACCSIZE;
-   goto libswd_memap_write_char_csw_error; 
+   goto libswd_memap_write_char_csw_error;
  }
  // Verify the count parameter to be access boundary.
  if (count%accsize) count=count-(count%accsize);
@@ -824,7 +824,7 @@ int libswd_memap_write_char_32(libswd_ctx_t *libswdctx, libswd_operation_t opera
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG,
             "LIBSWD_D: Entering libswd_memap_write_char_32(*libswdctx=%p, operation=%s, addr=0x%08X, count=0x%08X, **data=%p)...\n",
             (void*)libswdctx, libswd_operation_string(operation),
-            addr, count, (void**)data); 
+            addr, count, (void**)data);
 
  return libswd_memap_write_char_csw(libswdctx, operation, addr, count, data, LIBSWD_MEMAP_CSW_SIZE_32BIT|LIBSWD_MEMAP_CSW_ADDRINC_SINGLE);
 }
@@ -844,9 +844,9 @@ int libswd_memap_write_int(libswd_ctx_t *libswdctx, libswd_operation_t operation
  libswd_log(libswdctx, LIBSWD_LOGLEVEL_DEBUG,
             "LIBSWD_D: Entering libswd_memap_write_int(*libswdctx=%p, operation=%s, addr=0x%08X, count=0x%08X, **data=%p)...\n",
             (void*)libswdctx, libswd_operation_string(operation),
-            addr, count, (void*)data); 
+            addr, count, (void*)data);
 
- if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT; 
+ if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
@@ -946,7 +946,7 @@ int libswd_memap_write_int_csw(libswd_ctx_t *libswdctx, libswd_operation_t opera
             (void*)libswdctx, libswd_operation_string(operation),
             addr, count, (void**)data, csw );
 
- if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT; 
+ if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
@@ -966,9 +966,9 @@ int libswd_memap_write_int_csw(libswd_ctx_t *libswdctx, libswd_operation_t opera
    break;
   default:
    res=LIBSWD_ERROR_MEMAPACCSIZE;
-   goto libswd_memap_write_int_csw_error; 
+   goto libswd_memap_write_int_csw_error;
  }
- 
+
  // Initialize MEM-AP if necessary.
  if (!libswdctx->log.memap.initialized)
  {
@@ -1006,7 +1006,7 @@ int libswd_memap_write_int_32(libswd_ctx_t *libswdctx, libswd_operation_t operat
             "LIBSWD_D: Entering libswd_memap_write_int_32(*libswdctx=%p, operation=%s, addr=0x%08X, count=0x%08X, **data=%p)...\n",
             (void*)libswdctx, libswd_operation_string(operation),
             addr, count, (void**)data);
- 
+
  return libswd_memap_write_int_csw(libswdctx, operation, addr, count, data, LIBSWD_MEMAP_CSW_SIZE_32BIT|LIBSWD_MEMAP_CSW_ADDRINC_SINGLE);
 }
 

--- a/src/libswd_memap.c
+++ b/src/libswd_memap.c
@@ -57,7 +57,6 @@ int libswd_memap_init(libswd_ctx_t *libswdctx, libswd_operation_t operation){
  if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
 
  int res=0, *memapidr, *memapbase, *memapcswp, memapcsw;
- int dpabort, dpctrlstat, *dpctrlstatp;
 
  // Verify if DAP is already initialized, do so in necessary.
  if (!libswdctx->log.dp.initialized)
@@ -209,7 +208,7 @@ int libswd_memap_read_char(libswd_ctx_t *libswdctx, libswd_operation_t operation
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
- int i, loc, res=0, accsize=0, *memapcsw, *memaptar, *memapdrw;
+ int i, loc, res=0, accsize=0, *memapdrw;
  int chunk, chunks, chunksize=1024;
  float tdeltam;
  struct timeval tstart, tstop;
@@ -356,7 +355,7 @@ int libswd_memap_read_char_csw(libswd_ctx_t *libswdctx, libswd_operation_t opera
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
- int i, j, loc, res=0, accsize=0, *memapcsw, *memaptar, *memapdrw;
+ int res=0, accsize=0;
 
  // Calculate required access size based on CSW value.
  switch (csw&LIBSWD_MEMAP_CSW_SIZE)
@@ -440,7 +439,7 @@ int libswd_memap_read_int(libswd_ctx_t *libswdctx, libswd_operation_t operation,
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
- int i, loc, res, *memapcsw, *memaptar, *memapdrw;
+ int i, loc, res, *memapdrw;
  int chunk, chunks, chunksize=1024;
  float tdeltam;
  struct timeval tstart, tstop;
@@ -544,7 +543,7 @@ int libswd_memap_read_int_csw(libswd_ctx_t *libswdctx, libswd_operation_t operat
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
- int i, loc, res=0, accsize=0, *memapcsw, *memaptar, *memapdrw;
+ int res=0, accsize=0;
 
  // Calculate required access size based on CSW value.
  switch (csw&LIBSWD_MEMAP_CSW_SIZE)
@@ -627,7 +626,7 @@ int libswd_memap_write_char(libswd_ctx_t *libswdctx, libswd_operation_t operatio
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
- int i, loc, res=0, accsize=0, *memapcsw, *memaptar, *memapdrw;
+ int i, loc, res=0, accsize=0;
  int chunk, chunks, chunksize=1024;
  float tdeltam;
  struct timeval tstart, tstop;
@@ -767,7 +766,7 @@ int libswd_memap_write_char_csw(libswd_ctx_t *libswdctx, libswd_operation_t oper
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
- int i, loc, res=0, accsize=0, *memapcsw, *memaptar, *memapdrw;
+ int res=0, accsize=0;
 
  // Calculate required access size based on CSW value.
  switch (csw&LIBSWD_MEMAP_CSW_SIZE)
@@ -850,7 +849,7 @@ int libswd_memap_write_int(libswd_ctx_t *libswdctx, libswd_operation_t operation
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
- int i, loc, res=0, *memapcsw, *memaptar, *memapdrw;
+ int i, loc, res=0;
  int chunk, chunks, chunksize=1024;
  float tdeltam;
  struct timeval tstart, tstop;
@@ -950,7 +949,7 @@ int libswd_memap_write_int_csw(libswd_ctx_t *libswdctx, libswd_operation_t opera
  if (operation!=LIBSWD_OPERATION_ENQUEUE && operation!=LIBSWD_OPERATION_EXECUTE)
   return LIBSWD_ERROR_BADOPCODE;
 
- int i, loc, res=0, accsize=0, *memapcsw, *memaptar, *memapdrw;
+ int res=0, accsize=0;
 
  // Calculate required access size based on CSW value.
  switch (csw&LIBSWD_MEMAP_CSW_SIZE)

--- a/src/libswd_memap.c
+++ b/src/libswd_memap.c
@@ -239,6 +239,13 @@ int libswd_memap_read_char(libswd_ctx_t *libswdctx, libswd_operation_t operation
  }
  if (count%accsize) count=count-(count%accsize);
 
+ // Check for alignment issues.
+ if ((addr%accsize)!=0)
+ {
+  res=LIBSWD_ERROR_MEMAPALIGN;
+  goto libswd_memap_read_char_error;
+ }
+
  // Mark start time for transfer speed measurement.
  gettimeofday(&tstart, NULL);
 
@@ -633,6 +640,13 @@ int libswd_memap_write_char(libswd_ctx_t *libswdctx, libswd_operation_t operatio
    goto libswd_memap_write_char_error;
  }
  if (count%accsize) count=count-(count%accsize);
+
+ // check for alignment issues.
+ if ((addr%accsize)!=0)
+ {
+  res=LIBSWD_ERROR_MEMAPALIGN;
+  goto libswd_memap_write_char_error;
+ }
 
  // Mark start time for transfer speed measurement.
  gettimeofday(&tstart, NULL);


### PR DESCRIPTION
Dealing correctly with 8, 16 or 32 bit read and writes correctly. Using the correct byte-laning, and checking for alignment issues.
Bits of tidying up (whitespace, unused vars, etc..)
A bit of an optimisation when reading CPUID.